### PR TITLE
filter out leaves meta changes from being sent to the client (resolves #1714)

### DIFF
--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1570,6 +1570,10 @@ void cChunk::FastSetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockT
 	if (
 		a_SendToClients &&                  // ... we are told to do so AND ...
 		(
+			!(                                // ... the old and new blocktypes AREN'T leaves (because the client doesn't need meta updates)
+				((OldBlockType == E_BLOCK_LEAVES) && (a_BlockType == E_BLOCK_LEAVES)) ||
+				((OldBlockType == E_BLOCK_NEW_LEAVES) && (a_BlockType == E_BLOCK_NEW_LEAVES))
+			) ||                              // ... OR ...
 			(OldBlockMeta != a_BlockMeta) ||  // ... the meta value is different OR ...
 			!(                                // ... the old and new blocktypes AREN'T liquids (because client doesn't need to distinguish betwixt them):
 				((OldBlockType == E_BLOCK_STATIONARY_WATER) && (a_BlockType == E_BLOCK_WATER)) ||             // Replacing stationary water with water

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1573,13 +1573,15 @@ void cChunk::FastSetBlock(int a_RelX, int a_RelY, int a_RelZ, BLOCKTYPE a_BlockT
 			!(                                // ... the old and new blocktypes AREN'T leaves (because the client doesn't need meta updates)
 				((OldBlockType == E_BLOCK_LEAVES) && (a_BlockType == E_BLOCK_LEAVES)) ||
 				((OldBlockType == E_BLOCK_NEW_LEAVES) && (a_BlockType == E_BLOCK_NEW_LEAVES))
-			) ||                              // ... OR ...
-			(OldBlockMeta != a_BlockMeta) ||  // ... the meta value is different OR ...
-			!(                                // ... the old and new blocktypes AREN'T liquids (because client doesn't need to distinguish betwixt them):
-				((OldBlockType == E_BLOCK_STATIONARY_WATER) && (a_BlockType == E_BLOCK_WATER)) ||             // Replacing stationary water with water
-				((OldBlockType == E_BLOCK_WATER)            && (a_BlockType == E_BLOCK_STATIONARY_WATER)) ||  // Replacing water with stationary water
-				((OldBlockType == E_BLOCK_STATIONARY_LAVA)  && (a_BlockType == E_BLOCK_LAVA)) ||              // Replacing stationary water with water
-				((OldBlockType == E_BLOCK_LAVA)             && (a_BlockType == E_BLOCK_STATIONARY_LAVA))      // Replacing water with stationary water
+			) &&                              // ... AND ...
+			(
+				(OldBlockMeta != a_BlockMeta) ||  // ... the meta value is different OR ...
+				!(                                // ... the old and new blocktypes AREN'T liquids (because client doesn't need to distinguish betwixt them):
+					((OldBlockType == E_BLOCK_STATIONARY_WATER) && (a_BlockType == E_BLOCK_WATER)) ||             // Replacing stationary water with water
+					((OldBlockType == E_BLOCK_WATER)            && (a_BlockType == E_BLOCK_STATIONARY_WATER)) ||  // Replacing water with stationary water
+					((OldBlockType == E_BLOCK_STATIONARY_LAVA)  && (a_BlockType == E_BLOCK_LAVA)) ||              // Replacing stationary water with water
+					((OldBlockType == E_BLOCK_LAVA)             && (a_BlockType == E_BLOCK_STATIONARY_LAVA))      // Replacing water with stationary water
+				)
 			)
 		)
 	)


### PR DESCRIPTION
If I understand the issue, it's that the leave meta changes (e.g. decay) don't need to be sent to the client.
So in `cChunk::FastSetBlock(...)`, if the block is a leaf and hasn't changed, then the meta must have changed, so we skip it

I wasn't entirely sure how to run the tests, so I just ran `CIbuild.sh`