### PR TITLE
Add files generated on build in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,12 @@ nbproject/
 ipch/
 Win32/
 MCServer/MCServer
+MCServer/buildinfo
+MCServer/CONTRIBUTORS
+MCServer/LICENSE
+MCServer/Licenses
 MCServer/itemblacklist
+Testing/
 ChunkWorxSave.ini
 doxy/
 Profiling
@@ -14,6 +19,7 @@ cloc.xsl
 *.ncb
 *.user
 *.suo
+*.sqlite
 /EveryNight.cmd
 /UploadLuaAPI.cmd
 AllFiles.lst


### PR DESCRIPTION
Some files were always showing up on git status. We should ignore them to avoid committing them by accident.