### PR TITLE
Added cCryptoHash namespace to Lua API

### DIFF
--- a/MCServer/Plugins/APIDump/APIDesc.lua
+++ b/MCServer/Plugins/APIDump/APIDesc.lua
@@ -685,6 +685,28 @@ end</pre>
 			},
 		},  -- cCraftingRecipe
 
+		cCryptoHash =
+		{
+			Desc =
+			[[
+				Provides functions for generating cryptographic hashes.</p>
+				<p>
+				Note that all functions in this class are static, so they should be called in the dot convention:
+<pre class="prettyprint lang-lua">
+local Hash = cCryptoHash.sha1HexString("DataToHash")
+</pre></p>
+				<p>Each cryptographic hash has two variants, one returns the hash as a raw binary string, the other returns the hash as a hex-encoded string twice as long as the binary string.
+			]],
+			
+			Functions =
+			{
+				md5 = { Params = "Data", Return = "string", Notes = "(STATIC) Calculates the md5 hash of the data, returns it as a raw (binary) string of 16 characters." },
+				md5HexString = { Params = "Data", Return = "string", Notes = "(STATIC) Calculates the md5 hash of the data, returns it as a hex-encoded string of 32 characters." },
+				sha1 = { Params = "Data", Return = "string", Notes = "(STATIC) Calculates the sha1 hash of the data, returns it as a raw (binary) string of 20 characters." },
+				sha1HexString = { Params = "Data", Return = "string", Notes = "(STATIC) Calculates the sha1 hash of the data, returns it as a hex-encoded string of 40 characters." },
+			},
+		},  -- cCryptoHash
+		
 		cEnchantments =
 		{
 			Desc = [[
@@ -2929,7 +2951,7 @@ end
 				StringToMobType = {Params = "string", Return = "{{Globals#MobType|MobType}}", Notes = "<b>DEPRECATED!</b> Please use cMonster:StringToMobType(). Converts a string representation to a {{Globals#MobType|MobType}} enumerated value"},
 				StripColorCodes = {Params = "string", Return = "string", Notes = "Removes all control codes used by MC for colors and styles"},
 				TrimString = {Params = "string", Return = "string", Notes = "Trims whitespace at both ends of the string"},
-				md5 = {Params = "string", Return = "string", Notes = "converts a string to an md5 hash"},
+				md5 = {Params = "string", Return = "string", Notes = "<b>OBSOLETE</b>, use the {{cCryptoHash}} functions instead.<br>Converts a string to a raw binary md5 hash."},
 			},
 			ConstantGroups =
 			{

--- a/MCServer/Plugins/Debuggers/Debuggers.lua
+++ b/MCServer/Plugins/Debuggers/Debuggers.lua
@@ -1476,7 +1476,7 @@ function HandleWESel(a_Split, a_Player)
 	SelCuboid:Expand(NumBlocks, NumBlocks, 0, 0, NumBlocks, NumBlocks)
 	
 	-- Set the selection:
-	local IsSuccess = cPluginManager:CallPlugin("WorldEdit", "SetPlayerCuboidSelection", a_Player, SelCuboid)
+	IsSuccess = cPluginManager:CallPlugin("WorldEdit", "SetPlayerCuboidSelection", a_Player, SelCuboid)
 	if not(IsSuccess) then
 		a_Player:SendMessage(cCompositeChat():SetMessageType(mtFailure):AddTextPart("Cannot adjust selection, WorldEdit reported failure while setting new selection"))
 		return true
@@ -1606,17 +1606,36 @@ end
 
 
 
-function HandleConsoleSchedule(a_Split)
-	local prev = os.clock()
-	LOG("Scheduling a task for 2 seconds in the future (current os.clock is " .. prev .. ")")
-	cRoot:Get():GetDefaultWorld():ScheduleTask(40,
-		function ()
-			local current = os.clock()
-			local diff = current - prev
-			LOG("Scheduled function is called. Current os.clock is " .. current .. ", difference is " .. diff .. ")")
-		end
-	)
-	return true, "Task scheduled"
+-- List of hashing functions to test:
+local HashFunctions =
+{
+	{"md5", md5 },
+	{"cCryptoHash.md5", cCryptoHash.md5 },
+	{"cCryptoHash.md5HexString", cCryptoHash.md5HexString },
+	{"cCryptoHash.sha1", cCryptoHash.sha1 },
+	{"cCryptoHash.sha1HexString", cCryptoHash.sha1HexString },
+}
+
+-- List of strings to try hashing:
+local HashExamples =
+{
+	"",
+	"\0",
+	"test",
+}
+
+function HandleConsoleHash(a_Split)
+	for _, str in ipairs(HashExamples) do
+		LOG("Hashing string \"" .. str .. "\":")
+		for _, hash in ipairs(HashFunctions) do
+			if not(hash[2]) then
+				LOG("Hash function " .. hash[1] .. " doesn't exist in the API!")
+			else
+				LOG(hash[1] .. "() = " .. hash[2](str))
+			end
+		end  -- for hash - HashFunctions[]
+	end  -- for str - HashExamples[]
+	return true
 end
 
 
@@ -1699,6 +1718,23 @@ function HandleConsolePrepareChunk(a_Split)
 		end
 	)
 	return true
+end
+
+
+
+
+
+function HandleConsoleSchedule(a_Split)
+	local prev = os.clock()
+	LOG("Scheduling a task for 2 seconds in the future (current os.clock is " .. prev .. ")")
+	cRoot:Get():GetDefaultWorld():ScheduleTask(40,
+		function ()
+			local current = os.clock()
+			local diff = current - prev
+			LOG("Scheduled function is called. Current os.clock is " .. current .. ", difference is " .. diff .. ")")
+		end
+	)
+	return true, "Task scheduled"
 end
 
 

--- a/MCServer/Plugins/Debuggers/Info.lua
+++ b/MCServer/Plugins/Debuggers/Info.lua
@@ -200,21 +200,29 @@ g_PluginInfo =
 	
 	ConsoleCommands =
 	{
-		["sched"] =
+		["hash"] =
 		{
-			Handler = HandleConsoleSchedule,
-			HelpString = "Tests the world scheduling",
+			Handler = HandleConsoleHash,
+			HelpString = "Tests the crypto hashing functions",
 		},
+		
 		["loadchunk"] =
 		{
 			Handler = HandleConsoleLoadChunk,
 			HelpString = "Loads the specified chunk into memory",
 		},
+		
 		["preparechunk"] =
 		{
 			Handler = HandleConsolePrepareChunk,
 			HelpString = "Prepares the specified chunk completely (load / gen / light)",
-		}
+		},
+		
+		["sched"] =
+		{
+			Handler = HandleConsoleSchedule,
+			HelpString = "Tests the world scheduling",
+		},
 	},  -- ConsoleCommands
 }  -- g_PluginInfo
 


### PR DESCRIPTION
The new namespace provides access to the crypto hashing functions for Lua plugins. Each function has two variants, one returns the raw binary hash, the other returns the hash hex-encoded.