### PR TITLE
Use DoSetSpeed in AddSpeed* in Entity.cpp

### DIFF
--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -1913,10 +1913,7 @@ void cEntity::AddPosition(double a_AddPosX, double a_AddPosY, double a_AddPosZ)
 
 void cEntity::AddSpeed(double a_AddSpeedX, double a_AddSpeedY, double a_AddSpeedZ)
 {
-	m_Speed.x += a_AddSpeedX;
-	m_Speed.y += a_AddSpeedY;
-	m_Speed.z += a_AddSpeedZ;
-	WrapSpeed();
+	DoSetSpeed(m_Speed.x + a_AddSpeedX, m_Speed.y + a_AddSpeedY, m_Speed.z + a_AddSpeedZ);
 }
 
 
@@ -1925,8 +1922,7 @@ void cEntity::AddSpeed(double a_AddSpeedX, double a_AddSpeedY, double a_AddSpeed
 
 void cEntity::AddSpeedX(double a_AddSpeedX)
 {
-	m_Speed.x += a_AddSpeedX;
-	WrapSpeed();
+	AddSpeed(a_AddSpeedX, 0, 0);
 }
 
 
@@ -1935,8 +1931,7 @@ void cEntity::AddSpeedX(double a_AddSpeedX)
 
 void cEntity::AddSpeedY(double a_AddSpeedY)
 {
-	m_Speed.y += a_AddSpeedY;
-	WrapSpeed();
+	AddSpeed(0, a_AddSpeedY, 0);
 }
 
 
@@ -1945,8 +1940,7 @@ void cEntity::AddSpeedY(double a_AddSpeedY)
 
 void cEntity::AddSpeedZ(double a_AddSpeedZ)
 {
-	m_Speed.z += a_AddSpeedZ;
-	WrapSpeed();
+	AddSpeed(0, 0, a_AddSpeedZ);
 }
 
 


### PR DESCRIPTION
Change in issue #1770 . `DoSetSpeed` calls `WrapSpeed()`. Not sure if calling `DoSetSpeed` directly in the x, y, z versions of `AddSpeed` is preferred