### PR TITLE
Fixed creation of Fluid-Source-Blocks

### DIFF
--- a/src/Simulator/FloodyFluidSimulator.cpp
+++ b/src/Simulator/FloodyFluidSimulator.cpp
@@ -108,8 +108,9 @@ void cFloodyFluidSimulator::SimulateBlock(cChunk * a_Chunk, int a_RelX, int a_Re
 		{
 			SpreadXZ(a_Chunk, a_RelX, a_RelY, a_RelZ, NewMeta);
 		}
+		
 		// If source creation is on, check for it here:
-		else if (
+		if (
 			(m_NumNeighborsForSource > 0) &&  // Source creation is on
 			(MyMeta == m_Falloff) &&          // Only exactly one block away from a source (fast bail-out)
 			!IsPassableForFluid(Below) &&     // Only exactly 1 block deep


### PR DESCRIPTION
The else-Statement blocked the CheckNeighboursForSource function to get executed. This bricked the creation of new Fluid-Source-Blocks. Bugfix #1783 .