### PR TITLE
Removed Metavalue from Piston drops.

### DIFF
--- a/src/Blocks/BlockPiston.cpp
+++ b/src/Blocks/BlockPiston.cpp
@@ -61,6 +61,16 @@ void cBlockPistonHandler::OnDestroyed(cChunkInterface & a_ChunkInterface, cWorld
 
 
 
+void cBlockPistonHandler::ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta)
+{
+	// Returning Piston Item without Direction-Metavalue
+	a_Pickups.push_back(cItem(m_BlockType, 1));
+}
+
+
+
+
+
 bool cBlockPistonHandler::GetPlacementBlockTypeMeta(
 	cChunkInterface & a_ChunkInterface, cPlayer * a_Player,
 	int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace,

--- a/src/Blocks/BlockPiston.h
+++ b/src/Blocks/BlockPiston.h
@@ -15,6 +15,8 @@ public:
 	
 	virtual void OnDestroyed(cChunkInterface & a_ChunkInterface, cWorldInterface & a_WorldInterface, int a_BlockX, int a_BlockY, int a_BlockZ) override;
 
+	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta) override;
+
 	virtual bool GetPlacementBlockTypeMeta(
 		cChunkInterface & a_ChunkInterface, cPlayer * a_Player,
 		int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace,


### PR DESCRIPTION
Overridden `ConvertToPickups` function to prevent creation of an item with metavalue. Bugfix #1765 