### PR TITLE
Added cPluginLua::cResettable interface, used for scheduled tasks.

### DIFF
--- a/src/Blocks/BlockPiston.cpp
+++ b/src/Blocks/BlockPiston.cpp
@@ -169,7 +169,7 @@ void cBlockPistonHandler::ExtendPiston(int a_BlockX, int a_BlockY, int a_BlockZ,
 
 	a_World->SetBlock(a_BlockX, a_BlockY, a_BlockZ, pistonBlock, pistonMeta | 0x8);
 	a_World->SetBlock(extx, exty, extz, E_BLOCK_PISTON_EXTENSION, pistonMeta | (IsSticky(pistonBlock) ? 8 : 0), false);
-	a_World->ScheduleTask(PISTON_TICK_DELAY, new cWorld::cTaskSendBlockToAllPlayers(ScheduledBlocks));
+	a_World->ScheduleTask(PISTON_TICK_DELAY, std::make_shared<cWorld::cTaskSendBlockToAllPlayers>(ScheduledBlocks));
 }
 
 
@@ -219,7 +219,7 @@ void cBlockPistonHandler::RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ
 			std::vector<Vector3i> ScheduledBlocks;
 			ScheduledBlocks.push_back(Vector3i(a_BlockX, a_BlockY, a_BlockZ));
 			ScheduledBlocks.push_back(Vector3i(tempx, tempy, tempz));
-			a_World->ScheduleTask(PISTON_TICK_DELAY + 1, new cWorld::cTaskSendBlockToAllPlayers(ScheduledBlocks));
+			a_World->ScheduleTask(PISTON_TICK_DELAY + 1, std::make_shared<cWorld::cTaskSendBlockToAllPlayers>(ScheduledBlocks));
 			return;
 		}
 	}
@@ -229,7 +229,7 @@ void cBlockPistonHandler::RetractPiston(int a_BlockX, int a_BlockY, int a_BlockZ
 
 	std::vector<Vector3i> ScheduledBlocks;
 	ScheduledBlocks.push_back(Vector3i(a_BlockX, a_BlockY, a_BlockZ));
-	a_World->ScheduleTask(PISTON_TICK_DELAY + 1, new cWorld::cTaskSendBlockToAllPlayers(ScheduledBlocks));
+	a_World->ScheduleTask(PISTON_TICK_DELAY + 1, std::make_shared<cWorld::cTaskSendBlockToAllPlayers>(ScheduledBlocks));
 }
 
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -3167,14 +3167,14 @@ void cWorld::SaveAllChunks(void)
 
 void cWorld::QueueSaveAllChunks(void)
 {
-	QueueTask(make_unique<cWorld::cTaskSaveAllChunks>());
+	QueueTask(std::make_shared<cWorld::cTaskSaveAllChunks>());
 }
 
 
 
 
 
-void cWorld::QueueTask(std::unique_ptr<cTask> a_Task)
+void cWorld::QueueTask(cTaskPtr a_Task)
 {
 	cCSLock Lock(m_CSTasks);
 	m_Tasks.push_back(std::move(a_Task));
@@ -3184,7 +3184,7 @@ void cWorld::QueueTask(std::unique_ptr<cTask> a_Task)
 
 
 
-void cWorld::ScheduleTask(int a_DelayTicks, cTask * a_Task)
+void cWorld::ScheduleTask(int a_DelayTicks, cTaskPtr a_Task)
 {
 	Int64 TargetTick = a_DelayTicks + std::chrono::duration_cast<cTickTimeLong>(m_WorldAge).count();
 	
@@ -3194,11 +3194,11 @@ void cWorld::ScheduleTask(int a_DelayTicks, cTask * a_Task)
 	{
 		if ((*itr)->m_TargetTick >= TargetTick)
 		{
-			m_ScheduledTasks.insert(itr, make_unique<cScheduledTask>(TargetTick, a_Task));
+			m_ScheduledTasks.insert(itr, cScheduledTaskPtr(new cScheduledTask(TargetTick, a_Task)));
 			return;
 		}
 	}
-	m_ScheduledTasks.push_back(make_unique<cScheduledTask>(TargetTick, a_Task));
+	m_ScheduledTasks.push_back(cScheduledTaskPtr(new cScheduledTask(TargetTick, a_Task)));
 }
 
 

--- a/src/World.h
+++ b/src/World.h
@@ -106,7 +106,8 @@ public:
 		virtual void Run(cWorld & a_World) = 0;
 	} ;
 	
-	typedef std::vector<std::unique_ptr<cTask>> cTasks;
+	typedef SharedPtr<cTask> cTaskPtr;
+	typedef std::vector<cTaskPtr> cTasks;
 
 	
 	class cTaskSaveAllChunks :
@@ -691,11 +692,10 @@ public:
 	void QueueSaveAllChunks(void);  // tolua_export
 	
 	/** Queues a task onto the tick thread. The task object will be deleted once the task is finished */
-	void QueueTask(std::unique_ptr<cTask> a_Task);  // Exported in ManualBindings.cpp
+	void QueueTask(cTaskPtr a_Task);  // Exported in ManualBindings.cpp
 	
-	/** Queues a task onto the tick thread, with the specified delay.
-	The task object will be deleted once the task is finished */
-	void ScheduleTask(int a_DelayTicks, cTask * a_Task);
+	/** Queues a task onto the tick thread, with the specified delay. */
+	void ScheduleTask(int a_DelayTicks, cTaskPtr a_Task);
 
 	/** Returns the number of chunks loaded	 */
 	int GetNumChunks() const;  // tolua_export
@@ -867,20 +867,16 @@ private:
 	{
 	public:
 		Int64 m_TargetTick;
-		cTask * m_Task;
+		cTaskPtr m_Task;
 		
 		/** Creates a new scheduled task; takes ownership of the task object passed to it. */
-		cScheduledTask(Int64 a_TargetTick, cTask * a_Task) :
+		cScheduledTask(Int64 a_TargetTick, cTaskPtr a_Task) :
 			m_TargetTick(a_TargetTick),
 			m_Task(a_Task)
 		{
 		}
 		
-		virtual ~cScheduledTask()
-		{
-			delete m_Task;
-			m_Task = nullptr;
-		}
+		virtual ~cScheduledTask() {}
 	};
 
 	typedef std::unique_ptr<cScheduledTask> cScheduledTaskPtr;


### PR DESCRIPTION
This allows plugins to register objects that can "survive" the plugin unloading - they will simply bail out if the plugin is already unloaded, instead of referencing bad plugin data.
Fixes #1556.