### PR TITLE
Unify packetizer

### DIFF
--- a/Tools/ProtoProxy/Connection.cpp
+++ b/Tools/ProtoProxy/Connection.cpp
@@ -214,7 +214,11 @@ cConnection::cConnection(SOCKET a_ClientSocket, cServer & a_Server) :
 	Printf(m_LogNameBase, "Logs/Log_%d_%d", (int)time(NULL), a_ClientSocket);
 	AString fnam(m_LogNameBase);
 	fnam.append(".log");
-	m_LogFile = fopen(fnam.c_str(), "w");
+	#ifdef _WIN32
+		fopen_s(&m_LogFile, fnam.c_str(), "w");
+	#else
+		m_LogFile = fopen(fnam.c_str(), "w");
+	#endif
 	Log("Log file created");
 	printf("Connection is logged to file \"%s\"\n", fnam.c_str());
 }
@@ -788,14 +792,14 @@ bool cConnection::HandleClientHandshake(void)
 	// Read the packet from the client:
 	HANDLE_CLIENT_PACKET_READ(ReadVarInt,        UInt32,  ProtocolVersion);
 	HANDLE_CLIENT_PACKET_READ(ReadVarUTF8String, AString, ServerHost);
-	HANDLE_CLIENT_PACKET_READ(ReadBEShort,       short,   ServerPort);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt16,      UInt16,  ServerPort);
 	HANDLE_CLIENT_PACKET_READ(ReadVarInt,        UInt32,  NextState);
 	m_ClientBuffer.CommitRead();
 	
 	Log("Received an initial handshake packet from the client:");
 	Log("  ProtocolVersion = %u", ProtocolVersion);
 	Log("  ServerHost = \"%s\"", ServerHost.c_str());
-	Log("  ServerPort = %d", ServerPort);
+	Log("  ServerPort = %u", ServerPort);
 	Log("  NextState = %u", NextState);
 
 	// Send the same packet to the server, but with our port:
@@ -803,7 +807,7 @@ bool cConnection::HandleClientHandshake(void)
 	Packet.WriteVarInt(0);  // Packet type - initial handshake
 	Packet.WriteVarInt(ProtocolVersion);
 	Packet.WriteVarUTF8String(ServerHost);
-	Packet.WriteBEShort(m_Server.GetConnectPort());
+	Packet.WriteBEUInt16(m_Server.GetConnectPort());
 	Packet.WriteVarInt(NextState);
 	AString Pkt;
 	Packet.ReadAll(Pkt);
@@ -811,8 +815,8 @@ bool cConnection::HandleClientHandshake(void)
 	ToServer.WriteVarUTF8String(Pkt);
 	SERVERSEND(ToServer);
 	
-	m_ClientProtocolState = (int)NextState;
-	m_ServerProtocolState = (int)NextState;
+	m_ClientProtocolState = static_cast<int>(NextState);
+	m_ServerProtocolState = static_cast<int>(NextState);
 	
 	return true;
 }
@@ -852,10 +856,10 @@ bool cConnection::HandleClientLoginStart(void)
 
 bool cConnection::HandleClientAnimation(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,  char, Animation);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt8,   Int8,   Animation);
 	Log("Received a PACKET_ANIMATION from the client:");
-	Log("  EntityID: %d", EntityID);
+	Log("  EntityID: %u", EntityID);
 	Log("  Animation: %d", Animation);
 	COPY_TO_SERVER();
 	return true;
@@ -867,15 +871,15 @@ bool cConnection::HandleClientAnimation(void)
 
 bool cConnection::HandleClientBlockDig(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadByte,  Byte, Status);
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int,  BlockX);
-	HANDLE_CLIENT_PACKET_READ(ReadByte,  Byte, BlockY);
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int,  BlockZ);
-	HANDLE_CLIENT_PACKET_READ(ReadByte,  Byte, BlockFace);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, Status);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32, Int32, BlockX);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, BlockY);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32, Int32, BlockZ);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, BlockFace);
 	Log("Received a PACKET_BLOCK_DIG from the client:");
-	Log("  Status = %d", Status);
-	Log("  Pos = <%d, %d, %d>", BlockX, BlockY, BlockZ);
-	Log("  BlockFace = %d", BlockFace);
+	Log("  Status = %u (0x%02x)", Status, Status);
+	Log("  Pos = <%d, %u, %d>", BlockX, BlockY, BlockZ);
+	Log("  BlockFace = %u (0x%02x)", BlockFace, BlockFace);
 	COPY_TO_SERVER();
 	return true;
 }
@@ -886,23 +890,23 @@ bool cConnection::HandleClientBlockDig(void)
 
 bool cConnection::HandleClientBlockPlace(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int,  BlockX);
-	HANDLE_CLIENT_PACKET_READ(ReadByte,  Byte, BlockY);
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int,  BlockZ);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,  char, Face);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32, Int32, BlockX);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, BlockY);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32, Int32, BlockZ);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, Face);
 	AString Desc;
 	if (!ParseSlot(m_ClientBuffer, Desc))
 	{
 		return false;
 	}
-	HANDLE_CLIENT_PACKET_READ(ReadChar,  char, CursorX);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,  char, CursorY);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,  char, CursorZ);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, CursorX);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, CursorY);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, CursorZ);
 	Log("Received a PACKET_BLOCK_PLACE from the client:");
-	Log("  Block = {%d, %d, %d}", BlockX, BlockY, BlockZ);
-	Log("  Face = %d", Face);
+	Log("  Block = {%d, %u, %d}", BlockX, BlockY, BlockZ);
+	Log("  Face = %u (0x%02x)", Face, Face);
 	Log("  Item = %s", Desc.c_str());
-	Log("  Cursor = <%d, %d, %d>", CursorX, CursorY, CursorZ);
+	Log("  Cursor = <%u, %u, %u>", CursorX, CursorY, CursorZ);
 	COPY_TO_SERVER();
 	return true;
 }
@@ -926,9 +930,9 @@ bool cConnection::HandleClientChatMessage(void)
 
 bool cConnection::HandleClientClientStatuses(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadChar, char, Statuses);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, Statuses);
 	Log("Received a PACKET_CLIENT_STATUSES from the CLIENT:");
-	Log("  Statuses = %d", Statuses);
+	Log("  Statuses = %u (0x%02x)", Statuses, Statuses);
 	
 	COPY_TO_SERVER();
 	return true;
@@ -940,14 +944,14 @@ bool cConnection::HandleClientClientStatuses(void)
 
 bool cConnection::HandleClientCreativeInventoryAction(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadBEShort, short, SlotNum);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt16, UInt16, SlotNum);
 	AString Item;
 	if (!ParseSlot(m_ClientBuffer, Item))
 	{
 		return false;
 	}
 	Log("Received a PACKET_CREATIVE_INVENTORY_ACTION from the client:");
-	Log("  SlotNum = %d", SlotNum);
+	Log("  SlotNum = %u", SlotNum);
 	Log("  Item = %s", Item.c_str());
 	COPY_TO_SERVER();
 	return true;
@@ -972,12 +976,12 @@ bool cConnection::HandleClientDisconnect(void)
 
 bool cConnection::HandleClientEntityAction(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int,  PlayerID);
-	HANDLE_CLIENT_PACKET_READ(ReadByte,  Byte, ActionType);
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int,  HorseJumpBoost);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32, Int32, PlayerID);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, ActionType);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32, Int32, HorseJumpBoost);
 	Log("Received a PACKET_ENTITY_ACTION from the client:");
 	Log("  PlayerID = %d", PlayerID);
-	Log("  ActionType = %d", ActionType);
+	Log("  ActionType = %u", ActionType);
 	Log("  HorseJumpBoost = %d (0x%08x)", HorseJumpBoost, HorseJumpBoost);
 	COPY_TO_SERVER();
 	return true;
@@ -989,7 +993,7 @@ bool cConnection::HandleClientEntityAction(void)
 
 bool cConnection::HandleClientKeepAlive(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int, ID);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32, Int32, ID);
 	Log("Received a PACKET_KEEPALIVE from the client");
 	COPY_TO_SERVER();
 	return true;
@@ -1002,11 +1006,11 @@ bool cConnection::HandleClientKeepAlive(void)
 bool cConnection::HandleClientLocaleAndView(void)
 {
 	HANDLE_CLIENT_PACKET_READ(ReadVarUTF8String, AString, Locale);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,          char,    ViewDistance);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,          char,    ChatFlags);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,          char,    Unused);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,          char,    Difficulty);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,          char,    ShowCape);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt8,        Int8,    ViewDistance);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt8,        Int8,    ChatFlags);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt8,        Int8,    Unused);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt8,        Int8,    Difficulty);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt8,        Int8,    ShowCape);
 	Log("Received a PACKET_LOCALE_AND_VIEW from the client");
 	COPY_TO_SERVER();
 	return true;
@@ -1031,11 +1035,11 @@ bool cConnection::HandleClientPing(void)
 
 bool cConnection::HandleClientPlayerAbilities(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadChar,    char, Flags);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, Flags);
 	HANDLE_CLIENT_PACKET_READ(ReadBEFloat, float, FlyingSpeed);
 	HANDLE_CLIENT_PACKET_READ(ReadBEFloat, float, WalkingSpeed);
 	Log("Receives a PACKET_PLAYER_ABILITIES from the client:");
-	Log("  Flags = %d (0x%02x)", Flags, Flags);
+	Log("  Flags = %u (0x%02x)", Flags, Flags);
 	Log("  FlyingSpeed = %f", FlyingSpeed);
 	Log("  WalkingSpeed = %f", WalkingSpeed);
 	COPY_TO_SERVER();
@@ -1050,7 +1054,7 @@ bool cConnection::HandleClientPlayerLook(void)
 {
 	HANDLE_CLIENT_PACKET_READ(ReadBEFloat, float, Yaw);
 	HANDLE_CLIENT_PACKET_READ(ReadBEFloat, float, Pitch);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,    char,  OnGround);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, OnGround);
 	Log("Received a PACKET_PLAYER_LOOK from the client");
 	COPY_TO_SERVER();
 	return true;
@@ -1062,7 +1066,7 @@ bool cConnection::HandleClientPlayerLook(void)
 
 bool cConnection::HandleClientPlayerOnGround(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadChar, char, OnGround);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, OnGround);
 	Log("Received a PACKET_PLAYER_ON_GROUND from the client");
 	COPY_TO_SERVER();
 	return true;
@@ -1078,7 +1082,7 @@ bool cConnection::HandleClientPlayerPosition(void)
 	HANDLE_CLIENT_PACKET_READ(ReadBEDouble, double, PosY);
 	HANDLE_CLIENT_PACKET_READ(ReadBEDouble, double, Stance);
 	HANDLE_CLIENT_PACKET_READ(ReadBEDouble, double, PosZ);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,     char,   IsOnGround);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8,  UInt8,  IsOnGround);
 	Log("Received a PACKET_PLAYER_POSITION from the client");
 
 	// TODO: list packet contents
@@ -1099,7 +1103,7 @@ bool cConnection::HandleClientPlayerPositionLook(void)
 	HANDLE_CLIENT_PACKET_READ(ReadBEDouble, double, PosZ);
 	HANDLE_CLIENT_PACKET_READ(ReadBEFloat,  float,  Yaw);
 	HANDLE_CLIENT_PACKET_READ(ReadBEFloat,  float,  Pitch);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,     char,   IsOnGround);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8,  UInt8,  IsOnGround);
 	Log("Received a PACKET_PLAYER_POSITION_LOOK from the client");
 	Log("  Pos = {%.03f, %.03f, %.03f}", PosX, PosY, PosZ);
 	Log("  Stance = %.03f", Stance);
@@ -1117,7 +1121,7 @@ bool cConnection::HandleClientPlayerPositionLook(void)
 bool cConnection::HandleClientPluginMessage(void)
 {
 	HANDLE_CLIENT_PACKET_READ(ReadVarUTF8String, AString, ChannelName);
-	HANDLE_CLIENT_PACKET_READ(ReadBEUInt16,      UInt16,   Length);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt16,      UInt16,  Length);
 	AString Data;
 	if (!m_ClientBuffer.ReadString(Data, Length))
 	{
@@ -1136,7 +1140,7 @@ bool cConnection::HandleClientPluginMessage(void)
 
 bool cConnection::HandleClientSlotSelect(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadBEShort, short, SlotNum);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt16, Int16, SlotNum);
 	Log("Received a PACKET_SLOT_SELECT from the client");
 	Log("  SlotNum = %d", SlotNum);
 	COPY_TO_SERVER();
@@ -1186,9 +1190,9 @@ bool cConnection::HandleClientTabCompletion(void)
 
 bool cConnection::HandleClientUpdateSign(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt,         int,     BlockX);
-	HANDLE_CLIENT_PACKET_READ(ReadBEShort,       short,   BlockY);
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt,         int,     BlockZ);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32,       Int32,   BlockX);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt16,       Int16,   BlockY);
+	HANDLE_CLIENT_PACKET_READ(ReadBEInt32,       Int32,   BlockZ);
 	HANDLE_CLIENT_PACKET_READ(ReadVarUTF8String, AString, Line1);
 	HANDLE_CLIENT_PACKET_READ(ReadVarUTF8String, AString, Line2);
 	HANDLE_CLIENT_PACKET_READ(ReadVarUTF8String, AString, Line3);
@@ -1206,11 +1210,11 @@ bool cConnection::HandleClientUpdateSign(void)
 
 bool cConnection::HandleClientUseEntity(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,  char, MouseButton);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8,  UInt8,  MouseButton);
 	Log("Received a PACKET_USE_ENTITY from the client:");
 	Log("  EntityID = %d", EntityID);
-	Log("  MouseButton = %d", MouseButton);
+	Log("  MouseButton = %u", MouseButton);
 	COPY_TO_SERVER();
 	return true;
 }
@@ -1221,20 +1225,20 @@ bool cConnection::HandleClientUseEntity(void)
 
 bool cConnection::HandleClientWindowClick(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadChar,    char,  WindowID);
-	HANDLE_CLIENT_PACKET_READ(ReadBEShort, short, SlotNum);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,    char,  Button);
-	HANDLE_CLIENT_PACKET_READ(ReadBEShort, short, TransactionID);
-	HANDLE_CLIENT_PACKET_READ(ReadChar,    char,  Mode);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8,  UInt8,  WindowID);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt16, UInt16, SlotNum);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8,  UInt8,  Button);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt16, UInt16, TransactionID);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8,  UInt8,  Mode);
 	AString Item;
 	if (!ParseSlot(m_ClientBuffer, Item))
 	{
 		return false;
 	}
 	Log("Received a PACKET_WINDOW_CLICK from the client");
-	Log("  WindowID = %d", WindowID);
-	Log("  SlotNum = %d", SlotNum);
-	Log("  Button = %d, Mode = %d", Button, Mode);
+	Log("  WindowID = %u", WindowID);
+	Log("  SlotNum = %u", SlotNum);
+	Log("  Button = %u, Mode = %u", Button, Mode);
 	Log("  TransactionID = 0x%x", TransactionID);
 	Log("  ClickedItem = %s", Item.c_str());
 	COPY_TO_SERVER();
@@ -1247,9 +1251,9 @@ bool cConnection::HandleClientWindowClick(void)
 
 bool cConnection::HandleClientWindowClose(void)
 {
-	HANDLE_CLIENT_PACKET_READ(ReadChar, char, WindowID);
+	HANDLE_CLIENT_PACKET_READ(ReadBEUInt8, UInt8, WindowID);
 	Log("Received a PACKET_WINDOW_CLOSE from the client:");
-	Log("  WindowID = %d", WindowID);
+	Log("  WindowID = %u", WindowID);
 	COPY_TO_SERVER();
 	return true;
 }
@@ -1355,13 +1359,13 @@ bool cConnection::HandleServerLoginSuccess(void)
 
 bool cConnection::HandleServerAttachEntity(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  VehicleID);
-	HANDLE_SERVER_PACKET_READ(ReadBool,  bool, Leash);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32,  EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32,  VehicleID);
+	HANDLE_SERVER_PACKET_READ(ReadBool,     bool,    IsOnLeash);
 	Log("Received a PACKET_ATTACH_ENTITY from the server:");
-	Log("  EntityID = %d (0x%x)", EntityID, EntityID);
-	Log("  VehicleID = %d (0x%x)", VehicleID, VehicleID);
-	Log("  Leash = %s", Leash ? "true" : "false");
+	Log("  EntityID = %u (0x%x)", EntityID, EntityID);
+	Log("  VehicleID = %u (0x%x)", VehicleID, VehicleID);
+	Log("  IsOnLeash = %s", IsOnLeash ? "true" : "false");
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1372,15 +1376,15 @@ bool cConnection::HandleServerAttachEntity(void)
 
 bool cConnection::HandleServerBlockAction(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    BlockX);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short,  BlockY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    BlockZ);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   Byte1);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   Byte2);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32,  BlockX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16,  BlockY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32,  BlockZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,  Byte1);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,  Byte2);
 	HANDLE_SERVER_PACKET_READ(ReadVarInt,  UInt32, BlockID);
 	Log("Received a PACKET_BLOCK_ACTION from the server:");
 	Log("  Pos = {%d, %d, %d}", BlockX, BlockY, BlockZ);
-	Log("  Bytes = (%d, %d) == (0x%x, 0x%x)", Byte1, Byte2, Byte1, Byte2);
+	Log("  Bytes = (%u, %u) == (0x%x, 0x%x)", Byte1, Byte2, Byte1, Byte2);
 	Log("  BlockID = %u", BlockID);
 	COPY_TO_CLIENT();
 	return true;
@@ -1392,15 +1396,15 @@ bool cConnection::HandleServerBlockAction(void)
 
 bool cConnection::HandleServerBlockChange(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    BlockX);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   BlockY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    BlockZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32,  BlockX);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,  BlockY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32,  BlockZ);
 	HANDLE_SERVER_PACKET_READ(ReadVarInt,  UInt32, BlockType);
-	HANDLE_SERVER_PACKET_READ(ReadChar,    char,   BlockMeta);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,  BlockMeta);
 	Log("Received a PACKET_BLOCK_CHANGE from the server");
-	Log("  Pos = {%d, %d, %d}", BlockX, BlockY, BlockZ);
-	Log("  BlockType = %d (0x%x", BlockType, BlockType);
-	Log("  BlockMeta = %d", BlockMeta);
+	Log("  Pos = {%d, %u, %d}", BlockX, BlockY, BlockZ);
+	Log("  BlockType = %u (0x%x", BlockType, BlockType);
+	Log("  BlockMeta = %u", BlockMeta);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1411,10 +1415,10 @@ bool cConnection::HandleServerBlockChange(void)
 
 bool cConnection::HandleServerChangeGameState(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadChar,    char,  Reason);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,  Reason);
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat, float, Data);
 	Log("Received a PACKET_CHANGE_GAME_STATE from the server:");
-	Log("  Reason = %d", Reason);
+	Log("  Reason = %u", Reason);
 	Log("  Data = %f", Data);
 	COPY_TO_CLIENT();
 	return true;
@@ -1439,11 +1443,11 @@ bool cConnection::HandleServerChatMessage(void)
 
 bool cConnection::HandleServerCollectPickup(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, CollectedID);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, CollectorID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, CollectedID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, CollectorID);
 	Log("Received a PACKET_COLLECT_PICKUP from the server:");
-	Log("  CollectedID = %d", CollectedID);
-	Log("  CollectorID = %d", CollectorID);
+	Log("  CollectedID = %u", CollectedID);
+	Log("  CollectorID = %u", CollectorID);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1454,9 +1458,9 @@ bool cConnection::HandleServerCollectPickup(void)
 
 bool cConnection::HandleServerCompass(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, SpawnX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, SpawnY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, SpawnZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, SpawnX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, SpawnY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, SpawnZ);
 	Log("Received PACKET_COMPASS from the server:");
 	Log("  Spawn = {%d, %d, %d}", SpawnX, SpawnY, SpawnZ);
 	COPY_TO_CLIENT();
@@ -1469,7 +1473,7 @@ bool cConnection::HandleServerCompass(void)
 
 bool cConnection::HandleServerDestroyEntities(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadByte, Byte, NumEntities);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8, NumEntities);
 	if (!m_ServerBuffer.SkipRead(static_cast<size_t>(NumEntities) * 4))
 	{
 		return false;
@@ -1486,9 +1490,9 @@ bool cConnection::HandleServerDestroyEntities(void)
 
 bool cConnection::HandleServerEntity(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
 	Log("Received a PACKET_ENTITY from the server:");
-	Log("  EntityID = %d", EntityID);
+	Log("  EntityID = %u", EntityID);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1499,16 +1503,16 @@ bool cConnection::HandleServerEntity(void)
 
 bool cConnection::HandleServerEntityEquipment(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, SlotNum);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, SlotNum);
 	AString Item;
 	if (!ParseSlot(m_ServerBuffer, Item))
 	{
 		return false;
 	}
 	Log("Received a PACKET_ENTITY_EQUIPMENT from the server:");
-	Log("  EntityID = %d", EntityID);
-	Log("  SlotNum = %d", SlotNum);
+	Log("  EntityID = %u", EntityID);
+	Log("  SlotNum = %u", SlotNum);
 	Log("  Item = %s", Item.c_str());
 	COPY_TO_CLIENT();
 	return true;
@@ -1520,11 +1524,11 @@ bool cConnection::HandleServerEntityEquipment(void)
 
 bool cConnection::HandleServerEntityHeadLook(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, HeadYaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  HeadYaw);
 	Log("Received a PACKET_ENTITY_HEAD_LOOK from the server:");
-	Log("  EntityID = %d", EntityID);
-	Log("  HeadYaw = %d", HeadYaw);
+	Log("  EntityID = %u", EntityID);
+	Log("  HeadYaw = %u", HeadYaw);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1535,13 +1539,13 @@ bool cConnection::HandleServerEntityHeadLook(void)
 
 bool cConnection::HandleServerEntityLook(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, Yaw);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, Pitch);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32,  EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,   Yaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,   Pitch);
 	Log("Received a PACKET_ENTITY_LOOK from the server:");
-	Log("  EntityID = %d", EntityID);
-	Log("  Yaw = %d", Yaw);
-	Log("  Pitch = %d", Pitch);
+	Log("  EntityID = %u", EntityID);
+	Log("  Yaw = %u", Yaw);
+	Log("  Pitch = %u", Pitch);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1552,7 +1556,7 @@ bool cConnection::HandleServerEntityLook(void)
 
 bool cConnection::HandleServerEntityMetadata(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
 	AString Metadata;
 	if (!ParseMetadata(m_ServerBuffer, Metadata))
 	{
@@ -1561,8 +1565,9 @@ bool cConnection::HandleServerEntityMetadata(void)
 	AString HexDump;
 	CreateHexDump(HexDump, Metadata.data(), Metadata.size(), 32);
 	Log("Received a PACKET_ENTITY_METADATA from the server:");
-	Log("  EntityID = %d", EntityID);
-	Log("  Metadata, length = %d (0x%x):\n%s", Metadata.length(), Metadata.length(), HexDump.c_str());
+	Log("  EntityID = %u", EntityID);
+	auto len = static_cast<unsigned>(Metadata.length());
+	Log("  Metadata, length = %u (0x%x):\n%s", len, len, HexDump.c_str());
 	LogMetadata(Metadata, 4);
 	COPY_TO_CLIENT();
 	return true;
@@ -1574,24 +1579,24 @@ bool cConnection::HandleServerEntityMetadata(void)
 
 bool cConnection::HandleServerEntityProperties(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, Count);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, Count);
 	Log("Received a PACKET_ENTITY_PROPERTIES from the server:");
-	Log("  EntityID = %d", EntityID);
-	Log("  Count = %d", Count);
+	Log("  EntityID = %u", EntityID);
+	Log("  Count = %u", Count);
 	
-	for (int i = 0; i < Count; i++)
+	for (UInt32 i = 0; i < Count; i++)
 	{
 		HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Key);
 		HANDLE_SERVER_PACKET_READ(ReadBEDouble,      double,  Value);
-		HANDLE_SERVER_PACKET_READ(ReadBEShort, short, ListLength);
-		Log(" \"%s\" = %f; %d modifiers", Key.c_str(), Value, ListLength);
-		for (short j = 0; j < ListLength; j++)
+		HANDLE_SERVER_PACKET_READ(ReadBEUInt16,      UInt16, ListLength);
+		Log(" \"%s\" = %f; %u modifiers", Key.c_str(), Value, ListLength);
+		for (UInt16 j = 0; j < ListLength; j++)
 		{
-			HANDLE_SERVER_PACKET_READ(ReadBEInt64,  Int64,  UUIDHi);
-			HANDLE_SERVER_PACKET_READ(ReadBEInt64,  Int64,  UUIDLo);
+			HANDLE_SERVER_PACKET_READ(ReadBEUInt64, UInt64, UUIDHi);
+			HANDLE_SERVER_PACKET_READ(ReadBEUInt64, UInt64, UUIDLo);
 			HANDLE_SERVER_PACKET_READ(ReadBEDouble, double, DblVal);
-			HANDLE_SERVER_PACKET_READ(ReadByte,     Byte,   ByteVal);
+			HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  ByteVal);
 			Log("  [%d] = {0x%08llx%08llx, %f, %u}", j, UUIDHi, UUIDLo, DblVal, ByteVal);
 		}
 	}  // for i
@@ -1605,12 +1610,12 @@ bool cConnection::HandleServerEntityProperties(void)
 
 bool cConnection::HandleServerEntityRelativeMove(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, dx);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, dy);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, dz);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt8,   Int8,   dx);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt8,   Int8,   dy);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt8,   Int8,   dz);
 	Log("Received a PACKET_ENTITY_RELATIVE_MOVE from the server:");
-	Log("  EntityID = %d", EntityID);
+	Log("  EntityID = %u", EntityID);
 	Log("  RelMove = %s", PrintableAbsIntTriplet(dx, dy, dz).c_str());
 	COPY_TO_CLIENT();
 	return true;
@@ -1622,17 +1627,17 @@ bool cConnection::HandleServerEntityRelativeMove(void)
 
 bool cConnection::HandleServerEntityRelativeMoveLook(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, dx);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, dy);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, dz);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, Yaw);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, Pitch);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt8,   Int8,   dx);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt8,   Int8,   dy);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt8,   Int8,   dz);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  Yaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  Pitch);
 	Log("Received a PACKET_ENTITY_RELATIVE_MOVE_LOOK from the server:");
-	Log("  EntityID = %d", EntityID);
+	Log("  EntityID = %u", EntityID);
 	Log("  RelMove = %s", PrintableAbsIntTriplet(dx, dy, dz).c_str());
-	Log("  Yaw = %d", Yaw);
-	Log("  Pitch = %d", Pitch);
+	Log("  Yaw = %u", Yaw);
+	Log("  Pitch = %u", Pitch);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1643,11 +1648,11 @@ bool cConnection::HandleServerEntityRelativeMoveLook(void)
 
 bool cConnection::HandleServerEntityStatus(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, Status);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  Status);
 	Log("Received a PACKET_ENTITY_STATUS from the server:");
-	Log("  EntityID = %d", EntityID);
-	Log("  Status = %d", Status);
+	Log("  EntityID = %u", EntityID);
+	Log("  Status = %u (0x%02x)", Status, Status);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1658,17 +1663,17 @@ bool cConnection::HandleServerEntityStatus(void)
 
 bool cConnection::HandleServerEntityTeleport(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  AbsX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  AbsY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  AbsZ);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, Yaw);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, Pitch);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32,  EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,   AbsX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,   AbsY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,   AbsZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,   Yaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,   Pitch);
 	Log("Received a PACKET_ENTITY_TELEPORT from the server:");
-	Log("  EntityID = %d", EntityID);
+	Log("  EntityID = %u", EntityID);
 	Log("  Pos = %s", PrintableAbsIntTriplet(AbsX, AbsY, AbsZ).c_str());
-	Log("  Yaw = %d", Yaw);
-	Log("  Pitch = %d", Pitch);
+	Log("  Yaw = %u", Yaw);
+	Log("  Pitch = %u", Pitch);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1679,12 +1684,12 @@ bool cConnection::HandleServerEntityTeleport(void)
 
 bool cConnection::HandleServerEntityVelocity(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, VelocityX);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, VelocityY);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, VelocityZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16,  Int16,  VelocityX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16,  Int16,  VelocityY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16,  Int16,  VelocityZ);
 	Log("Received a PACKET_ENTITY_VELOCITY from the server:");
-	Log("  EntityID = %d", EntityID);
+	Log("  EntityID = %u", EntityID);
 	Log("  Velocity = %s", PrintableAbsIntTriplet(VelocityX, VelocityY, VelocityZ, 8000).c_str());
 	COPY_TO_CLIENT();
 	return true;
@@ -1703,12 +1708,12 @@ bool cConnection::HandleServerExplosion(void)
 	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, NumRecords);
 	std::vector<sCoords> Records;
 	Records.reserve(NumRecords);
-	int PosXI = (int)PosX, PosYI = (int)PosY, PosZI = (int)PosZ;
+	int PosXI = static_cast<int>(PosX), PosYI = static_cast<int>(PosY), PosZI = static_cast<int>(PosZ);
 	for (UInt32 i = 0; i < NumRecords; i++)
 	{
-		HANDLE_SERVER_PACKET_READ(ReadChar, char, rx);
-		HANDLE_SERVER_PACKET_READ(ReadChar, char, ry);
-		HANDLE_SERVER_PACKET_READ(ReadChar, char, rz);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt8, Int8, rx);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt8, Int8, ry);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt8, Int8, rz);
 		Records.push_back(sCoords(PosXI + rx, PosYI + ry, PosZI + rz));
 	}
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat, float, PlayerMotionX);
@@ -1734,10 +1739,10 @@ bool cConnection::HandleServerExplosion(void)
 bool cConnection::HandleServerIncrementStatistic(void)
 {
 	// 0xc8
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, StatisticID);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, Amount);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, StatisticID);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  Amount);
 	Log("Received a PACKET_INCREMENT_STATISTIC from the server:");
-	Log("  StatisticID = %d (0x%x)", StatisticID, StatisticID);
+	Log("  StatisticID = %u (0x%x)", StatisticID, StatisticID);
 	Log("  Amount = %d", Amount);
 	COPY_TO_CLIENT();
 	return true;
@@ -1749,18 +1754,18 @@ bool cConnection::HandleServerIncrementStatistic(void)
 
 bool cConnection::HandleServerJoinGame(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadChar,          char,    GameMode);
-	HANDLE_SERVER_PACKET_READ(ReadChar,          char,    Dimension);
-	HANDLE_SERVER_PACKET_READ(ReadChar,          char,    Difficulty);
-	HANDLE_SERVER_PACKET_READ(ReadChar,          char,    MaxPlayers);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32,      UInt32,  EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   GameMode);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   Dimension);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   Difficulty);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   MaxPlayers);
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, LevelType);
 	Log("Received a PACKET_LOGIN from the server:");
-	Log("  EntityID = %d",      EntityID);
-	Log("  GameMode = %d",      GameMode);
-	Log("  Dimension = %d",     Dimension);
-	Log("  Difficulty = %d",    Difficulty);
-	Log("  MaxPlayers = %d",    MaxPlayers);
+	Log("  EntityID = %u",      EntityID);
+	Log("  GameMode = %u",      GameMode);
+	Log("  Dimension = %u",     Dimension);
+	Log("  Difficulty = %u",    Difficulty);
+	Log("  MaxPlayers = %u",    MaxPlayers);
 	Log("  LevelType = \"%s\"", LevelType.c_str());
 	COPY_TO_CLIENT();
 	return true;
@@ -1772,9 +1777,9 @@ bool cConnection::HandleServerJoinGame(void)
 
 bool cConnection::HandleServerKeepAlive(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int, PingID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, PingID);
 	Log("Received a PACKET_KEEP_ALIVE from the server:");
-	Log("  ID = %d", PingID);
+	Log("  ID = %u", PingID);
 	COPY_TO_CLIENT()
 	return true;
 }
@@ -1856,11 +1861,11 @@ bool cConnection::HandleServerKick(void)
 
 bool cConnection::HandleServerMapChunk(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,    int,    ChunkX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,    int,    ChunkZ);
-	HANDLE_SERVER_PACKET_READ(ReadChar,     char,   IsContiguous);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort,  short,  PrimaryBitmap);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort,  short,  AdditionalBitmap);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  ChunkX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  ChunkZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  IsContiguous);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, PrimaryBitmap);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, AdditionalBitmap);
 	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, CompressedSize);
 	AString CompressedData;
 	if (!m_ServerBuffer.ReadString(CompressedData, CompressedSize))
@@ -1899,10 +1904,10 @@ bool cConnection::HandleServerMapChunkBulk(void)
 	ChunkMetas.reserve(ChunkCount);
 	for (short i = 0; i < ChunkCount; i++)
 	{
-		HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   ChunkX);
-		HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   ChunkZ);
-		HANDLE_SERVER_PACKET_READ(ReadBEShort, short, PrimaryBitmap);
-		HANDLE_SERVER_PACKET_READ(ReadBEShort, short, AddBitmap);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, ChunkX);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, ChunkZ);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16, PrimaryBitmap);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16, AddBitmap);
 		ChunkMetas.push_back(sChunkMeta(ChunkX, ChunkZ, PrimaryBitmap, AddBitmap));
 	}
 	
@@ -1932,8 +1937,8 @@ bool cConnection::HandleServerMapChunkBulk(void)
 
 bool cConnection::HandleServerMultiBlockChange(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,    int,    ChunkX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,    int,    ChunkZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  ChunkX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  ChunkZ);
 	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, NumBlocks);
 	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, DataSize);
 	AString BlockChangeData;
@@ -1955,16 +1960,16 @@ bool cConnection::HandleServerMultiBlockChange(void)
 bool cConnection::HandleServerNamedSoundEffect(void)
 {
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, SoundName);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   PosX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   PosY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   PosZ);
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat,       float,   Volume);
-	HANDLE_SERVER_PACKET_READ(ReadByte,          Byte,    Pitch);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   Pitch);
 	Log("Received a PACKET_NAMED_SOUND_EFFECT from the server:");
 	Log("  SoundName = \"%s\"", SoundName.c_str());
 	Log("  Pos = %s", PrintableAbsIntTriplet(PosX, PosY, PosZ, 8).c_str());
 	Log("  Volume = %f", Volume);
-	Log("  Pitch = %d", Pitch);
+	Log("  Pitch = %u", Pitch);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -1975,11 +1980,11 @@ bool cConnection::HandleServerNamedSoundEffect(void)
 
 bool cConnection::HandleServerPlayerAbilities(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadChar, char, Flags);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8, Flags);
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat, float, FlyingSpeed);
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat, float, WalkingSpeed);
 	Log("Received a PACKET_PLAYER_ABILITIES from the server:");
-	Log("  Flags = %d (0x%02x)", Flags, Flags);
+	Log("  Flags = %u (0x%02x)", Flags, Flags);
 	Log("  FlyingSpeed = %f", FlyingSpeed);
 	Log("  WalkingSpeed = %f", WalkingSpeed);
 	COPY_TO_CLIENT();
@@ -1992,11 +1997,11 @@ bool cConnection::HandleServerPlayerAbilities(void)
 
 bool cConnection::HandleServerPlayerAnimation(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadVarInt, UInt32, PlayerID);
-	HANDLE_SERVER_PACKET_READ(ReadByte,   Byte,   AnimationID);
+	HANDLE_SERVER_PACKET_READ(ReadVarInt,  UInt32, PlayerID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,  AnimationID);
 	Log("Received a PACKET_PLAYER_ANIMATION from the server:");
 	Log("  PlayerID: %u (0x%x)", PlayerID, PlayerID);
-	Log("  Animation: %d", AnimationID);
+	Log("  Animation: %u", AnimationID);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -2008,10 +2013,10 @@ bool cConnection::HandleServerPlayerAnimation(void)
 bool cConnection::HandleServerPlayerListItem(void)
 {
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, PlayerName);
-	HANDLE_SERVER_PACKET_READ(ReadChar,            char,    IsOnline);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort,         short,   Ping);
+	HANDLE_SERVER_PACKET_READ(ReadBool,          bool,    IsOnline);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16,      UInt16,  Ping);
 	Log("Received a PACKET_PLAYERLIST_ITEM from the server:");
-	Log("  PlayerName = \"%s\"", PlayerName.c_str());
+	Log("  PlayerName = \"%s\" (%s)", PlayerName.c_str(), IsOnline ? "online" : "offline");
 	Log("  Ping = %d", Ping);
 	COPY_TO_CLIENT();
 	return true;
@@ -2028,7 +2033,7 @@ bool cConnection::HandleServerPlayerPositionLook(void)
 	HANDLE_SERVER_PACKET_READ(ReadBEDouble, double, PosZ);
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat,  float,  Yaw);
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat,  float,  Pitch);
-	HANDLE_SERVER_PACKET_READ(ReadChar,     char,   IsOnGround);
+	HANDLE_SERVER_PACKET_READ(ReadBool,     bool,   IsOnGround);
 	Log("Received a PACKET_PLAYER_POSITION_LOOK from the server");
 
 	// TODO: list packet contents
@@ -2063,14 +2068,14 @@ bool cConnection::HandleServerPluginMessage(void)
 
 bool cConnection::HandleServerRespawn(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     Dimension);
-	HANDLE_SERVER_PACKET_READ(ReadChar,          char,    Difficulty);
-	HANDLE_SERVER_PACKET_READ(ReadChar,          char,    GameMode);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,     Dimension);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,    Difficulty);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,    GameMode);
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, LevelType);
 	Log("Received a respawn packet from the server:");
 	Log("  Dimension = %d", Dimension);
-	Log("  Difficulty = %d", Difficulty);
-	Log("  GameMode = %d", GameMode);
+	Log("  Difficulty = %u", Difficulty);
+	Log("  GameMode = %u", GameMode);
 	Log("  LevelType = \"%s\"", LevelType.c_str());
 	COPY_TO_CLIENT();
 	return true;
@@ -2082,13 +2087,13 @@ bool cConnection::HandleServerRespawn(void)
 
 bool cConnection::HandleServerSetExperience(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEFloat, float, ExperienceBar);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, Level);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, TotalExperience);
+	HANDLE_SERVER_PACKET_READ(ReadBEFloat,  float,  ExperienceBar);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, Level);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, TotalExperience);
 	Log("Received a PACKET_SET_EXPERIENCE from the server:");
 	Log("  ExperienceBar = %.05f", ExperienceBar);
-	Log("  Level = %d", Level);
-	Log("  TotalExperience = %d", TotalExperience);
+	Log("  Level = %u", Level);
+	Log("  TotalExperience = %u", TotalExperience);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -2099,16 +2104,16 @@ bool cConnection::HandleServerSetExperience(void)
 
 bool cConnection::HandleServerSetSlot(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadChar,    char,  WindowID);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, SlotNum);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  WindowID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, SlotNum);
 	AString Item;
 	if (!ParseSlot(m_ServerBuffer, Item))
 	{
 		return false;
 	}
 	Log("Received a PACKET_SET_SLOT from the server:");
-	Log("  WindowID = %d", WindowID);
-	Log("  SlotNum = %d", SlotNum);
+	Log("  WindowID = %u", WindowID);
+	Log("  SlotNum = %u", SlotNum);
 	Log("  Item = %s", Item.c_str());
 	COPY_TO_CLIENT();
 	return true;
@@ -2120,9 +2125,9 @@ bool cConnection::HandleServerSetSlot(void)
 
 bool cConnection::HandleServerSlotSelect(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadByte, Byte, SlotNum);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8, SlotNum);
 	Log("Received a PACKET_SLOT_SELECT from the server:");
-	Log("  SlotNum = %d", SlotNum);
+	Log("  SlotNum = %u", SlotNum);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -2133,17 +2138,17 @@ bool cConnection::HandleServerSlotSelect(void)
 
 bool cConnection::HandleServerSoundEffect(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   EffectID);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   PosX);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,  PosY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   PosZ);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   Data);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,  NoVolumeDecrease);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, EffectID);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, PosX);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8, PosY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, PosZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, Data);
+	HANDLE_SERVER_PACKET_READ(ReadBool,    bool,  NoVolumeDecrease);
 	Log("Received a PACKET_SOUND_EFFECT from the server:");
 	Log("  EffectID = %d", EffectID);
 	Log("  Pos = {%d, %d, %d}", PosX, PosY, PosZ);
 	Log("  Data = %d", Data);
-	Log("  NoVolumeDecrease = %d", NoVolumeDecrease);
+	Log("  NoVolumeDecrease = %s", NoVolumeDecrease ? "true" : "false");
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -2154,15 +2159,15 @@ bool cConnection::HandleServerSoundEffect(void)
 
 bool cConnection::HandleServerSpawnExperienceOrbs(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadVarInt,  UInt32, EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosZ);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short,  Count);
+	HANDLE_SERVER_PACKET_READ(ReadVarInt,   UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, Count);
 	Log("Received a SPAWN_EXPERIENCE_ORBS packet from the server:");
 	Log("  EntityID = %u (0x%x)", EntityID, EntityID);
 	Log("  Pos = %s", PrintableAbsIntTriplet(PosX, PosY, PosZ).c_str());
-	Log("  Count = %d", Count);
+	Log("  Count = %u", Count);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -2174,16 +2179,16 @@ bool cConnection::HandleServerSpawnExperienceOrbs(void)
 bool cConnection::HandleServerSpawnMob(void)
 {
 	HANDLE_SERVER_PACKET_READ(ReadVarInt,  UInt32, EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadChar,    char,   MobType);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosZ);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   Yaw);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   Pitch);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   HeadYaw);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short,  VelocityX);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short,  VelocityY);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short,  VelocityZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,   MobType);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32,    PosX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32,    PosY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32,    PosZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,   Yaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,   Pitch);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8,   HeadYaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16,  VelocityX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16,  VelocityY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16,  VelocityZ);
 	AString Metadata;
 	if (!ParseMetadata(m_ServerBuffer, Metadata))
 	{
@@ -2193,11 +2198,12 @@ bool cConnection::HandleServerSpawnMob(void)
 	CreateHexDump(HexDump, Metadata.data(), Metadata.size(), 32);
 	Log("Received a PACKET_SPAWN_MOB from the server:");
 	Log("  EntityID = %u (0x%x)", EntityID, EntityID);
-	Log("  MobType = %d", MobType);
+	Log("  MobType = %u (0x%x)", MobType, MobType);
 	Log("  Pos = %s", PrintableAbsIntTriplet(PosX, PosY, PosZ).c_str());
-	Log("  Angles = [%d, %d, %d]", Yaw, Pitch, HeadYaw);
+	Log("  Angles = [%u, %u, %u]", Yaw, Pitch, HeadYaw);
 	Log("  Velocity = %s", PrintableAbsIntTriplet(VelocityX, VelocityY, VelocityZ, 8000).c_str());
-	Log("  Metadata, length = %d (0x%x):\n%s", Metadata.length(), Metadata.length(), HexDump.c_str());
+	auto len = static_cast<unsigned>(Metadata.length());
+	Log("  Metadata, length = %u (0x%x):\n%s", len, len, HexDump.c_str());
 	LogMetadata(Metadata, 4);
 	COPY_TO_CLIENT();
 	return true;
@@ -2240,12 +2246,12 @@ bool cConnection::HandleServerSpawnNamedEntity(void)
 		HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Signature)
 		Data.push_back(sSpawnData(Name, Value, Signature));
 	}
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosZ);
-	HANDLE_SERVER_PACKET_READ(ReadByte,          Byte,    Yaw);
-	HANDLE_SERVER_PACKET_READ(ReadByte,          Byte,    Pitch);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort,       short,   CurrentItem);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  Yaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  Pitch);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, SelectedItem);
 	AString Metadata;
 	if (!ParseMetadata(m_ServerBuffer, Metadata))
 	{
@@ -2265,9 +2271,10 @@ bool cConnection::HandleServerSpawnNamedEntity(void)
 		);
 	}  // for itr - Data[]
 	Log("  Pos = %s", PrintableAbsIntTriplet(PosX, PosY, PosZ).c_str());
-	Log("  Rotation = <yaw %d, pitch %d>", Yaw, Pitch);
-	Log("  CurrentItem = %d", CurrentItem);
-	Log("  Metadata, length = %d (0x%x):\n%s", Metadata.length(), Metadata.length(), HexDump.c_str());
+	Log("  Rotation = <yaw %u, pitch %u>", Yaw, Pitch);
+	Log("  SelectedItem = %u", SelectedItem);
+	auto len = static_cast<unsigned>(Metadata.length());
+	Log("  Metadata, length = %u (0x%x):\n%s", len, len, HexDump.c_str());
 	LogMetadata(Metadata, 4);
 	COPY_TO_CLIENT();
 	return true;
@@ -2294,26 +2301,26 @@ bool cConnection::HandleServerSpawnObjectVehicle(void)
 		// Only log up to 128 bytes
 		Buffer.erase(128, AString::npos);
 	}
-	DataLog(Buffer.data(), Buffer.size(), "Buffer while parsing the PACKET_SPAWN_OBJECT_VEHICLE packet (%d bytes):", Buffer.size());
+	DataLog(Buffer.data(), Buffer.size(), "Buffer while parsing the PACKET_SPAWN_OBJECT_VEHICLE packet (%u bytes):", static_cast<unsigned>(Buffer.size()));
 	#endif  // _DEBUG
 	
-	HANDLE_SERVER_PACKET_READ(ReadVarInt,  UInt32, EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   ObjType);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    PosZ);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   Pitch);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,   Yaw);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,    DataIndicator);
+	HANDLE_SERVER_PACKET_READ(ReadVarInt,   UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  ObjType);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  PosZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  Pitch);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  Yaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, DataIndicator);
 	AString ExtraData;
-	short VelocityX = 0;
-	short VelocityY = 0;
-	short VelocityZ = 0;
+	Int16 VelocityX = 0;
+	Int16 VelocityY = 0;
+	Int16 VelocityZ = 0;
 	if (DataIndicator != 0)
 	{
-		HANDLE_SERVER_PACKET_READ(ReadBEShort, short, SpeedX);
-		HANDLE_SERVER_PACKET_READ(ReadBEShort, short, SpeedY);
-		HANDLE_SERVER_PACKET_READ(ReadBEShort, short, SpeedZ);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16, SpeedX);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16, SpeedY);
+		HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16, SpeedZ);
 		VelocityX = SpeedX; VelocityY = SpeedY; VelocityZ = SpeedZ;  // Speed vars are local to this scope, but we need them available later
 		/*
 		// This doesn't seem to work - for a falling block I'm getting no extra data at all
@@ -2340,14 +2347,14 @@ bool cConnection::HandleServerSpawnObjectVehicle(void)
 	}
 	Log("Received a PACKET_SPAWN_OBJECT_VEHICLE from the server:");
 	Log("  EntityID = %u (0x%x)", EntityID, EntityID);
-	Log("  ObjType = %d (0x%x)", ObjType, ObjType);
+	Log("  ObjType = %u (0x%x)", ObjType, ObjType);
 	Log("  Pos = %s", PrintableAbsIntTriplet(PosX, PosY, PosZ).c_str());
-	Log("  Rotation = <yaw %d, pitch %d>", Yaw, Pitch);
-	Log("  DataIndicator = %d (0x%x)", DataIndicator, DataIndicator);
+	Log("  Rotation = <yaw %u, pitch %u>", Yaw, Pitch);
+	Log("  DataIndicator = %u (0x%x)", DataIndicator, DataIndicator);
 	if (DataIndicator != 0)
 	{
 		Log("  Velocity = %s", PrintableAbsIntTriplet(VelocityX, VelocityY, VelocityZ, 8000).c_str());
-		DataLog(ExtraData.data(), ExtraData.size(), "  ExtraData size = %d:", ExtraData.size());
+		DataLog(ExtraData.data(), ExtraData.size(), "  ExtraData size = %u:", static_cast<unsigned>(ExtraData.size()));
 	}
 	COPY_TO_CLIENT();
 	return true;
@@ -2361,10 +2368,10 @@ bool cConnection::HandleServerSpawnPainting(void)
 {
 	HANDLE_SERVER_PACKET_READ(ReadVarInt,        UInt32,  EntityID);
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, ImageName);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     PosZ);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,         int,     Direction);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   PosX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   PosY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   PosZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   Direction);
 	Log("Received a PACKET_SPAWN_PAINTING from the server:");
 	Log("  EntityID = %u", EntityID);
 	Log("  ImageName = \"%s\"", ImageName.c_str());
@@ -2380,23 +2387,23 @@ bool cConnection::HandleServerSpawnPainting(void)
 
 bool cConnection::HandleServerSpawnPickup(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
 	AString ItemDesc;
 	if (!ParseSlot(m_ServerBuffer, ItemDesc))
 	{
 		return false;
 	}
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   PosX);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   PosY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,   int,   PosZ);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,  Rotation);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,  Pitch);
-	HANDLE_SERVER_PACKET_READ(ReadByte,    Byte,  Roll);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, PosX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, PosY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32, Int32, PosZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8, Yaw);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8, Pitch);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8, Roll);
 	Log("Received a PACKET_SPAWN_PICKUP from the server:");
 	Log("  EntityID = %d", EntityID);
 	Log("  Item = %s", ItemDesc.c_str());
 	Log("  Pos = %s", PrintableAbsIntTriplet(PosX, PosY, PosZ).c_str());
-	Log("  Angles = [%d, %d, %d]", Rotation, Pitch, Roll);
+	Log("  Angles = [%u, %u, %u]", Yaw, Pitch, Roll);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -2446,6 +2453,10 @@ bool cConnection::HandleServerStatusResponse(void)
 	{
 		Response.assign(Response.substr(0, idx + sizeof(DescSearch) - 1) + "ProtoProxy: " + Response.substr(idx + sizeof(DescSearch) - 1));
 	}
+	else
+	{
+		Log("Cannot find the description json element, ProtoProxy signature not inserted");
+	}
 	cByteBuffer Packet(Response.size() + 50);
 	Packet.WriteVarInt(0);  // Packet type - status response
 	Packet.WriteVarUTF8String(Response);
@@ -2492,8 +2503,8 @@ bool cConnection::HandleServerTabCompletion(void)
 
 bool cConnection::HandleServerTimeUpdate(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt64, Int64, WorldAge);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt64, Int64, TimeOfDay);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt64, UInt64, WorldAge);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt64, UInt64, TimeOfDay);
 	Log("Received a PACKET_TIME_UPDATE from the server");
 	COPY_TO_CLIENT();
 	return true;
@@ -2506,7 +2517,7 @@ bool cConnection::HandleServerTimeUpdate(void)
 bool cConnection::HandleServerUpdateHealth(void)
 {
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat, float, Health);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, Food);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16, Int16, Food);
 	HANDLE_SERVER_PACKET_READ(ReadBEFloat, float, Saturation);
 	Log("Received a PACKET_UPDATE_HEALTH from the server");
 	COPY_TO_CLIENT();
@@ -2519,9 +2530,9 @@ bool cConnection::HandleServerUpdateHealth(void)
 
 bool cConnection::HandleServerUpdateSign(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,           int,   BlockX);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort,         short, BlockY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,           int,   BlockZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   BlockX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16,       Int16,   BlockY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,       Int32,   BlockZ);
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Line1);
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Line2);
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Line3);
@@ -2539,10 +2550,10 @@ bool cConnection::HandleServerUpdateSign(void)
 
 bool cConnection::HandleServerUpdateTileEntity(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,    int,    BlockX);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort,  short,  BlockY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt,    int,    BlockZ);
-	HANDLE_SERVER_PACKET_READ(ReadByte,     Byte,   Action);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  BlockX);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt16,  Int16,  BlockY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  BlockZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  Action);
 	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, DataLength);	
 
 	AString Data;
@@ -2552,8 +2563,8 @@ bool cConnection::HandleServerUpdateTileEntity(void)
 	}
 	Log("Received a PACKET_UPDATE_TILE_ENTITY from the server:");
 	Log("  Block = {%d, %d, %d}", BlockX, BlockY, BlockZ);
-	Log("  Action = %d", Action);
-	DataLog(Data.data(), Data.size(), "  Data (%u bytes)", Data.size());
+	Log("  Action = %u", Action);
+	DataLog(Data.data(), Data.size(), "  Data (%u bytes)", DataLength);
 
 	// Save metadata to a file:
 	AString fnam;
@@ -2576,13 +2587,13 @@ bool cConnection::HandleServerUpdateTileEntity(void)
 
 bool cConnection::HandleServerUseBed(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  EntityID);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  BedX);
-	HANDLE_SERVER_PACKET_READ(ReadByte,  Byte, BedY);
-	HANDLE_SERVER_PACKET_READ(ReadBEInt, int,  BedZ);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, EntityID);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  BedX);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  BedY);
+	HANDLE_SERVER_PACKET_READ(ReadBEInt32,  Int32,  BedZ);
 	Log("Received a use bed packet from the server:");
-	Log("  EntityID = %d", EntityID);
-	Log("  Bed = {%d, %d, %d}", BedX, BedY, BedZ);
+	Log("  EntityID = %u", EntityID);
+	Log("  Bed = {%d, %u, %d}", BedX, BedY, BedZ);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -2593,9 +2604,9 @@ bool cConnection::HandleServerUseBed(void)
 
 bool cConnection::HandleServerWindowClose(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadChar, char, WindowID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8, UInt8, WindowID);
 	Log("Received a PACKET_WINDOW_CLOSE from the server:");
-	Log("  WindowID = %d", WindowID);
+	Log("  WindowID = %u", WindowID);
 	COPY_TO_CLIENT();
 	return true;
 }
@@ -2606,20 +2617,20 @@ bool cConnection::HandleServerWindowClose(void)
 
 bool cConnection::HandleServerWindowContents(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadChar, char, WindowID);
-	HANDLE_SERVER_PACKET_READ(ReadBEShort, short, NumSlots);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,  UInt8,  WindowID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt16, UInt16, NumSlots);
 	Log("Received a PACKET_WINDOW_CONTENTS from the server:");
-	Log("  WindowID = %d", WindowID);
-	Log("  NumSlots = %d", NumSlots);
+	Log("  WindowID = %u", WindowID);
+	Log("  NumSlots = %u", NumSlots);
 	AStringVector Items;
-	for (short i = 0; i < NumSlots; i++)
+	for (UInt16 i = 0; i < NumSlots; i++)
 	{
 		AString Item;
 		if (!ParseSlot(m_ServerBuffer, Item))
 		{
 			return false;
 		}
-		Log("    %d: %s", i, Item.c_str());
+		Log("    %u: %s", i, Item.c_str());
 	}
 
 	COPY_TO_CLIENT();
@@ -2632,25 +2643,25 @@ bool cConnection::HandleServerWindowContents(void)
 
 bool cConnection::HandleServerWindowOpen(void)
 {
-	HANDLE_SERVER_PACKET_READ(ReadChar,            char,    WindowID);
-	HANDLE_SERVER_PACKET_READ(ReadChar,            char,    WindowType);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   WindowID);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   WindowType);
 	HANDLE_SERVER_PACKET_READ(ReadVarUTF8String, AString, Title);
-	HANDLE_SERVER_PACKET_READ(ReadByte,            Byte,    NumSlots);
-	HANDLE_SERVER_PACKET_READ(ReadByte,            Byte,    UseProvidedTitle);
-	int HorseEntityID = 0;
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   NumSlots);
+	HANDLE_SERVER_PACKET_READ(ReadBEUInt8,       UInt8,   UseProvidedTitle);
+	UInt32 HorseEntityID = 0;
 	if (WindowType == 11)  // Horse / Donkey / Mule
 	{
-		HANDLE_SERVER_PACKET_READ(ReadBEInt, int, intHorseInt);
+		HANDLE_SERVER_PACKET_READ(ReadBEUInt32, UInt32, intHorseInt);
 		HorseEntityID = intHorseInt;
 	}
 	Log("Received a PACKET_WINDOW_OPEN from the server:");
-	Log("  WindowID = %d", WindowID);
-	Log("  WindowType = %d", WindowType);
-	Log("  Title = \"%s\", Use = %d", Title.c_str(), UseProvidedTitle);
-	Log("  NumSlots = %d", NumSlots);
+	Log("  WindowID = %u", WindowID);
+	Log("  WindowType = %u (0x%02x)", WindowType, WindowType);
+	Log("  Title = \"%s\", Use = %u", Title.c_str(), UseProvidedTitle);
+	Log("  NumSlots = %u", NumSlots);
 	if (WindowType == 11)
 	{
-		Log("  HorseEntityID = %d (0x%08x)", HorseEntityID, HorseEntityID);
+		Log("  HorseEntityID = %u (0x%08x)", HorseEntityID, HorseEntityID);
 	}
 	COPY_TO_CLIENT();
 	return true;
@@ -2680,7 +2691,7 @@ bool cConnection::HandleServerUnknownPacket(UInt32 a_PacketType, UInt32 a_Packet
 bool cConnection::ParseSlot(cByteBuffer & a_Buffer, AString & a_ItemDesc)
 {
 	short ItemType;
-	if (!a_Buffer.ReadBEShort(ItemType))
+	if (!a_Buffer.ReadBEInt16(ItemType))
 	{
 		return false;
 	}
@@ -2693,11 +2704,11 @@ bool cConnection::ParseSlot(cByteBuffer & a_Buffer, AString & a_ItemDesc)
 	{
 		return false;
 	}
-	char ItemCount;
-	short ItemDamage;
+	Int8 ItemCount;
+	Int16 ItemDamage;
 	UInt16 MetadataLength;
-	a_Buffer.ReadChar(ItemCount);  // We already know we can read these bytes - we checked before.
-	a_Buffer.ReadBEShort(ItemDamage);
+	a_Buffer.ReadBEInt8(ItemCount);  // We already know we can read these bytes - we checked before.
+	a_Buffer.ReadBEInt16(ItemDamage);
 	a_Buffer.ReadBEUInt16(MetadataLength);
 	Printf(a_ItemDesc, "%d:%d * %d", ItemType, ItemDamage, ItemCount);
 	if (MetadataLength <= 0)
@@ -2734,8 +2745,8 @@ bool cConnection::ParseSlot(cByteBuffer & a_Buffer, AString & a_ItemDesc)
 
 bool cConnection::ParseMetadata(cByteBuffer & a_Buffer, AString & a_Metadata)
 {
-	Byte x;
-	if (!a_Buffer.ReadByte(x))
+	UInt8 x;
+	if (!a_Buffer.ReadBEUInt8(x))
 	{
 		return false;
 	}
@@ -2800,7 +2811,7 @@ bool cConnection::ParseMetadata(cByteBuffer & a_Buffer, AString & a_Metadata)
 			return false;
 		}
 		a_Metadata.append(data);
-		if (!a_Buffer.ReadByte(x))
+		if (!a_Buffer.ReadBEUInt8(x))
 		{
 			return false;
 		}
@@ -2826,7 +2837,7 @@ void cConnection::LogMetadata(const AString & a_Metadata, size_t a_IndentCount)
 		{
 			case 0:
 			{
-				Log("%sbyte[%u] = %d", Indent.c_str(), Index, a_Metadata[pos + 1]);
+				Log("%sbyte[%u] = %u", Indent.c_str(), Index, static_cast<unsigned char>(a_Metadata[pos + 1]));
 				pos += 1;
 				break;
 			}
@@ -2940,13 +2951,13 @@ void cConnection::SendEncryptionKeyResponse(const AString & a_ServerPublicKey, c
 	// Send the packet to the server:
 	Log("Sending PACKET_ENCRYPTION_KEY_RESPONSE to the SERVER");
 	cByteBuffer ToServer(1024);
-	ToServer.WriteByte(0x01);  // To server: Encryption key response
-	ToServer.WriteBEShort((short)sizeof(EncryptedSecret));
+	ToServer.WriteBEUInt8(0x01);  // To server: Encryption key response
+	ToServer.WriteBEUInt16(static_cast<UInt16>(sizeof(EncryptedSecret)));
 	ToServer.WriteBuf(EncryptedSecret, sizeof(EncryptedSecret));
-	ToServer.WriteBEShort((short)sizeof(EncryptedNonce));
+	ToServer.WriteBEUInt16(static_cast<UInt16>(sizeof(EncryptedNonce)));
 	ToServer.WriteBuf(EncryptedNonce, sizeof(EncryptedNonce));
-	DataLog(EncryptedSecret, sizeof(EncryptedSecret), "Encrypted secret (%u bytes)", (unsigned)sizeof(EncryptedSecret));
-	DataLog(EncryptedNonce,  sizeof(EncryptedNonce),  "Encrypted nonce (%u bytes)",  (unsigned)sizeof(EncryptedNonce));
+	DataLog(EncryptedSecret, sizeof(EncryptedSecret), "Encrypted secret (%u bytes)", static_cast<unsigned>(sizeof(EncryptedSecret)));
+	DataLog(EncryptedNonce,  sizeof(EncryptedNonce),  "Encrypted nonce (%u bytes)",  static_cast<unsigned>(sizeof(EncryptedNonce)));
 	cByteBuffer Len(5);
 	Len.WriteVarInt(static_cast<UInt32>(ToServer.GetReadableSpace()));
 	SERVERSEND(Len);

--- a/Tools/ProtoProxy/Connection.cpp
+++ b/Tools/ProtoProxy/Connection.cpp
@@ -805,11 +805,11 @@ bool cConnection::HandleClientHandshake(void)
 
 	// Send the same packet to the server, but with our port:
 	cByteBuffer Packet(512);
-	Packet.WriteVarInt(0);  // Packet type - initial handshake
-	Packet.WriteVarInt(ProtocolVersion);
+	Packet.WriteVarInt32(0);  // Packet type - initial handshake
+	Packet.WriteVarInt32(ProtocolVersion);
 	Packet.WriteVarUTF8String(ServerHost);
 	Packet.WriteBEUInt16(m_Server.GetConnectPort());
-	Packet.WriteVarInt(NextState);
+	Packet.WriteVarInt32(NextState);
 	AString Pkt;
 	Packet.ReadAll(Pkt);
 	cByteBuffer ToServer(512);
@@ -2459,7 +2459,7 @@ bool cConnection::HandleServerStatusResponse(void)
 		Log("Cannot find the description json element, ProtoProxy signature not inserted");
 	}
 	cByteBuffer Packet(Response.size() + 50);
-	Packet.WriteVarInt(0);  // Packet type - status response
+	Packet.WriteVarInt32(0);  // Packet type - status response
 	Packet.WriteVarUTF8String(Response);
 	AString Pkt;
 	Packet.ReadAll(Pkt);
@@ -2775,7 +2775,7 @@ bool cConnection::ParseMetadata(cByteBuffer & a_Buffer, AString & a_Metadata)
 				}
 				rs = rs - static_cast<int>(a_Buffer.GetReadableSpace());
 				cByteBuffer LenBuf(8);
-				LenBuf.WriteVarInt(Len);
+				LenBuf.WriteVarInt32(Len);
 				AString VarLen;
 				LenBuf.ReadAll(VarLen);
 				a_Metadata.append(VarLen);
@@ -2960,7 +2960,7 @@ void cConnection::SendEncryptionKeyResponse(const AString & a_ServerPublicKey, c
 	DataLog(EncryptedSecret, sizeof(EncryptedSecret), "Encrypted secret (%u bytes)", static_cast<unsigned>(sizeof(EncryptedSecret)));
 	DataLog(EncryptedNonce,  sizeof(EncryptedNonce),  "Encrypted nonce (%u bytes)",  static_cast<unsigned>(sizeof(EncryptedNonce)));
 	cByteBuffer Len(5);
-	Len.WriteVarInt(static_cast<UInt32>(ToServer.GetReadableSpace()));
+	Len.WriteVarInt32(static_cast<UInt32>(ToServer.GetReadableSpace()));
 	SERVERSEND(Len);
 	SERVERSEND(ToServer);
 	m_ServerState = csEncryptedUnderstood;

--- a/Tools/ProtoProxy/Connection.cpp
+++ b/Tools/ProtoProxy/Connection.cpp
@@ -8,6 +8,7 @@
 #include "Server.h"
 #include <iostream>
 #include "PolarSSL++/CryptoKey.h"
+#include "../../src/Logger.h"
 
 #ifdef _WIN32
 	#include <direct.h>  // For _mkdir()

--- a/Tools/ProtoProxy/Globals.h
+++ b/Tools/ProtoProxy/Globals.h
@@ -247,7 +247,3 @@ public:
 
 
 
-
-#define LOGERROR   printf
-#define LOGINFO    printf
-#define LOGWARNING printf

--- a/Tools/ProtoProxy/Globals.h
+++ b/Tools/ProtoProxy/Globals.h
@@ -73,13 +73,15 @@
 
 
 // Integral types with predefined sizes:
-typedef long long Int64;
-typedef int       Int32;
-typedef short     Int16;
+typedef signed long long Int64;
+typedef signed int       Int32;
+typedef signed short     Int16;
+typedef signed char      Int8;
 
 typedef unsigned long long UInt64;
 typedef unsigned int       UInt32;
 typedef unsigned short     UInt16;
+typedef unsigned char      UInt8;
 
 typedef unsigned char Byte;
 

--- a/Tools/ProtoProxy/ProtoProxy.cpp
+++ b/Tools/ProtoProxy/ProtoProxy.cpp
@@ -5,6 +5,8 @@
 
 #include "Globals.h"
 #include "Server.h"
+#include "../../src/Logger.h"
+#include "../../src/LoggerListeners.h"
 
 
 
@@ -12,8 +14,16 @@
 
 int main(int argc, char ** argv)
 {
+	// Initialize logging subsystem:
+	cLogger::InitiateMultithreading();
+	auto consoleLogListener = MakeConsoleListener();
+	auto fileLogListener = new cFileListener();
+	cLogger::GetInstance().AttachListener(consoleLogListener);
+	cLogger::GetInstance().AttachListener(fileLogListener);
+
 	int ListenPort  = (argc > 1) ? atoi(argv[1]) : 25564;
 	int ConnectPort = (argc > 2) ? atoi(argv[2]) : 25565;
+	printf("Initializing ProtoProxy. Listen port %d, connect port %d.\n", ListenPort, ConnectPort);
 	cServer Server;
 	int res = Server.Init(ListenPort, ConnectPort);
 	if (res != 0)

--- a/Tools/ProtoProxy/Server.h
+++ b/Tools/ProtoProxy/Server.h
@@ -21,7 +21,7 @@ class cServer
 	SOCKET m_ListenSocket;
 	cRsaPrivateKey m_PrivateKey;
 	AString m_PublicKeyDER;
-	short m_ConnectPort;
+	UInt16 m_ConnectPort;
 	
 public:
 	cServer(void);
@@ -32,7 +32,7 @@ public:
 	cRsaPrivateKey & GetPrivateKey(void) { return m_PrivateKey; }
 	const AString & GetPublicKeyDER (void) { return m_PublicKeyDER; }
 	
-	short GetConnectPort(void) const { return m_ConnectPort; }
+	UInt16 GetConnectPort(void) const { return m_ConnectPort; }
 } ;
 
 

--- a/src/Bindings/ManualBindings.cpp
+++ b/src/Bindings/ManualBindings.cpp
@@ -590,7 +590,7 @@ static int tolua_DoWith(lua_State* tolua_S)
 template <
 	class Ty1,
 	class Ty2,
-	bool (Ty1::*Func1)(int, cItemCallback<Ty2> &)
+	bool (Ty1::*Func1)(UInt32, cItemCallback<Ty2> &)
 >
 static int tolua_DoWithID(lua_State* tolua_S)
 {
@@ -3866,6 +3866,10 @@ void ManualBindings::Bind(lua_State * tolua_S)
 		
 		BindRankManager(tolua_S);
 		BindNetwork(tolua_S);
+
+		tolua_beginmodule(tolua_S, "cEntity");
+			tolua_constant(tolua_S, "INVALID_ID", cEntity::INVALID_ID);
+		tolua_endmodule(tolua_S);
 
 	tolua_endmodule(tolua_S);
 }

--- a/src/BlockEntities/DispenserEntity.cpp
+++ b/src/BlockEntities/DispenserEntity.cpp
@@ -105,7 +105,7 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 		{
 			double MobX = 0.5 + (DispX + DispChunk->GetPosX() * cChunkDef::Width);
 			double MobZ = 0.5 + (DispZ + DispChunk->GetPosZ() * cChunkDef::Width);
-			if (m_World->SpawnMob(MobX, DispY, MobZ, static_cast<eMonsterType>(m_Contents.GetSlot(a_SlotNum).m_ItemDamage)) >= 0)
+			if (m_World->SpawnMob(MobX, DispY, MobZ, static_cast<eMonsterType>(m_Contents.GetSlot(a_SlotNum).m_ItemDamage)) != cEntity::INVALID_ID)
 			{
 				m_Contents.ChangeSlotCount(a_SlotNum, -1);
 			}
@@ -144,29 +144,37 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 		case E_ITEM_FIRE_CHARGE:
 		{
-			SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkFireCharge, GetShootVector(Meta) * 20);
-			m_Contents.ChangeSlotCount(a_SlotNum, -1);
+			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkFireCharge, GetShootVector(Meta) * 20) != cEntity::INVALID_ID)
+			{
+				m_Contents.ChangeSlotCount(a_SlotNum, -1);
+			}
 			break;
 		}
 
 		case E_ITEM_ARROW:
 		{
-			SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkArrow, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0));
-			m_Contents.ChangeSlotCount(a_SlotNum, -1);
+			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkArrow, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
+			{
+				m_Contents.ChangeSlotCount(a_SlotNum, -1);
+			}
 			break;
 		}
 
 		case E_ITEM_SNOWBALL:
 		{
-			SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkSnowball, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0));
-			m_Contents.ChangeSlotCount(a_SlotNum, -1);
+			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkSnowball, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
+			{
+				m_Contents.ChangeSlotCount(a_SlotNum, -1);
+			}
 			break;
 		}
 
 		case E_ITEM_EGG:
 		{
-			SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkEgg, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0));
-			m_Contents.ChangeSlotCount(a_SlotNum, -1);
+			if (SpawnProjectileFromDispenser(BlockX, DispY, BlockZ, cProjectileEntity::pkEgg, GetShootVector(Meta) * 20 + Vector3d(0, 1, 0)) != cEntity::INVALID_ID)
+			{
+				m_Contents.ChangeSlotCount(a_SlotNum, -1);
+			}
 			break;
 		}
 
@@ -188,9 +196,14 @@ void cDispenserEntity::DropSpenseFromSlot(cChunk & a_Chunk, int a_SlotNum)
 
 
 
-void cDispenserEntity::SpawnProjectileFromDispenser(int a_BlockX, int a_BlockY, int a_BlockZ, cProjectileEntity::eKind a_Kind, const Vector3d & a_ShootVector)
+UInt32 cDispenserEntity::SpawnProjectileFromDispenser(int a_BlockX, int a_BlockY, int a_BlockZ, cProjectileEntity::eKind a_Kind, const Vector3d & a_ShootVector)
 {
-	m_World->CreateProjectile(static_cast<double>(a_BlockX + 0.5), static_cast<double>(a_BlockY + 0.5), static_cast<double>(a_BlockZ + 0.5), a_Kind, nullptr, nullptr, &a_ShootVector);
+	return m_World->CreateProjectile(
+		static_cast<double>(a_BlockX + 0.5),
+		static_cast<double>(a_BlockY + 0.5),
+		static_cast<double>(a_BlockZ + 0.5),
+		a_Kind, nullptr, nullptr, &a_ShootVector
+	);
 }
 
 

--- a/src/BlockEntities/DispenserEntity.h
+++ b/src/BlockEntities/DispenserEntity.h
@@ -24,8 +24,9 @@ public:
 
 	// tolua_begin
 	
-	/** Spawns a projectile of the given kind in front of the dispenser with the specified speed. */
-	void SpawnProjectileFromDispenser(int a_BlockX, int a_BlockY, int a_BlockZ, cProjectileEntity::eKind a_Kind, const Vector3d & a_Speed);
+	/** Spawns a projectile of the given kind in front of the dispenser with the specified speed.
+	Returns the UniqueID of the spawned projectile, or 0 on failure. */
+	UInt32 SpawnProjectileFromDispenser(int a_BlockX, int a_BlockY, int a_BlockZ, cProjectileEntity::eKind a_Kind, const Vector3d & a_Speed);
 
 	/** Returns a unit vector in the cardinal direction of where the dispenser is facing. */
 	Vector3d GetShootVector(NIBBLETYPE a_Meta);

--- a/src/BlockEntities/MobSpawnerEntity.cpp
+++ b/src/BlockEntities/MobSpawnerEntity.cpp
@@ -169,7 +169,7 @@ void cMobSpawnerEntity::SpawnEntity(void)
 
 					Monster->SetPosition(PosX, RelY, PosZ);
 					Monster->SetYaw(Random.NextFloat() * 360.0f);
-					if (Chunk->GetWorld()->SpawnMobFinalize(Monster) != mtInvalidType)
+					if (Chunk->GetWorld()->SpawnMobFinalize(Monster) != cEntity::INVALID_ID)
 					{
 						EntitiesSpawned = true;
 						Chunk->BroadcastSoundParticleEffect(2004, (int)(PosX * 8.0), (int)(RelY * 8.0), (int)(PosZ * 8.0), 0);

--- a/src/Blocks/WorldInterface.h
+++ b/src/Blocks/WorldInterface.h
@@ -30,14 +30,16 @@ public:
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities: */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool IsPlayerCreated = false) = 0;
 	
-	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified: */
+	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) = 0;
 	
-	/** Spawns a mob of the specified type. Returns the mob's EntityID if recognized and spawned, <0 otherwise */
-	virtual int SpawnMob(double a_PosX, double a_PosY, double a_PosZ, eMonsterType a_MonsterType) = 0;
+	/** Spawns a mob of the specified type.
+	Returns the mob's UniqueID if recognized and spawned, or cEntity::INVALID_ID on failure. */
+	virtual UInt32 SpawnMob(double a_PosX, double a_PosY, double a_PosZ, eMonsterType a_MonsterType) = 0;
 
-	/** Spawns an experience orb at the given location with the given reward. It returns the UniqueID of the spawned experience orb. */
-	virtual int SpawnExperienceOrb(double a_X, double a_Y, double a_Z, int a_Reward) = 0;
+	/** Spawns an experience orb at the given location with the given reward.
+	Returns the UniqueID of the spawned experience orb, or cEntity::INVALID_ID on failure. */
+	virtual UInt32 SpawnExperienceOrb(double a_X, double a_Y, double a_Z, int a_Reward) = 0;
 
 	/** Calls the callback for the block entity at the specified coords; returns false if there's no block entity at those coords, true if found */
 	virtual bool DoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBlockEntityCallback & a_Callback) = 0;

--- a/src/ByteBuffer.cpp
+++ b/src/ByteBuffer.cpp
@@ -762,10 +762,10 @@ bool cByteBuffer::WriteLEInt32(Int32 a_Value)
 	CHECK_THREAD
 	CheckValid();
 	#ifdef IS_LITTLE_ENDIAN
-		return WriteBuf((const char *)&a_Value, 4);
+		return WriteBuf(reinterpret_cast<const char *>(&a_Value), 4);
 	#else
 		int Value = ((a_Value >> 24) & 0xff) | ((a_Value >> 16) & 0xff00) | ((a_Value >> 8) & 0xff0000) | (a_Value & 0xff000000);
-		return WriteBuf((const char *)&Value, 4);
+		return WriteBuf(reinterpret_cast<const char *>(&Value), 4);
 	#endif
 }
 
@@ -773,11 +773,15 @@ bool cByteBuffer::WriteLEInt32(Int32 a_Value)
 
 
 
-bool cByteBuffer::WritePosition(Int32 a_BlockX, Int32 a_BlockY, Int32 a_BlockZ)
+bool cByteBuffer::WritePosition64(Int32 a_BlockX, Int32 a_BlockY, Int32 a_BlockZ)
 {
 	CHECK_THREAD
 	CheckValid();
-	return WriteBEInt64(((Int64)a_BlockX & 0x3FFFFFF) << 38 | ((Int64)a_BlockY & 0xFFF) << 26 | ((Int64)a_BlockZ & 0x3FFFFFF));
+	return WriteBEInt64(
+		(static_cast<Int64>(a_BlockX & 0x3FFFFFF) << 38) |
+		(static_cast<Int64>(a_BlockY & 0xFFF) << 26) |
+		(static_cast<Int64>(a_BlockZ & 0x3FFFFFF))
+	);
 }
 
 

--- a/src/ByteBuffer.h
+++ b/src/ByteBuffer.h
@@ -96,7 +96,7 @@ public:
 	bool WriteVarInt         (UInt32 a_Value);
 	bool WriteVarUTF8String  (const AString & a_Value);  // string length as VarInt, then string as UTF-8
 	bool WriteLEInt32        (Int32 a_Value);
-	bool WritePosition       (Int32 a_BlockX, Int32 a_BlockY, Int32 a_BlockZ);
+	bool WritePosition64     (Int32 a_BlockX, Int32 a_BlockY, Int32 a_BlockZ);
 	
 	/** Reads a_Count bytes into a_Buffer; returns true if successful */
 	bool ReadBuf(void * a_Buffer, size_t a_Count);

--- a/src/ByteBuffer.h
+++ b/src/ByteBuffer.h
@@ -64,19 +64,20 @@ public:
 	bool ReadBEDouble       (double & a_Value);
 	bool ReadBool           (bool & a_Value);
 	bool ReadBEUTF16String16(AString & a_Value);  // string length as BE short, then string as UTF-16BE
-	bool ReadVarInt         (UInt32 & a_Value);
+	bool ReadVarInt32       (UInt32 & a_Value);
+	bool ReadVarInt64       (UInt64 & a_Value);
 	bool ReadVarUTF8String  (AString & a_Value);  // string length as VarInt, then string as UTF-8
 	bool ReadLEInt          (int & a_Value);
-	bool ReadPosition       (int & a_BlockX, int & a_BlockY, int & a_BlockZ);
+	bool ReadPosition64     (int & a_BlockX, int & a_BlockY, int & a_BlockZ);
 
-	/** Reads VarInt, assigns it to anything that can be assigned from an UInt32 (unsigned short, char, Byte, double, ...) */
+	/** Reads VarInt, assigns it to anything that can be assigned from an UInt64 (unsigned short, char, Byte, double, ...) */
 	template <typename T> bool ReadVarInt(T & a_Value)
 	{
-		UInt32 v;
-		bool res = ReadVarInt(v);
+		UInt64 v;
+		bool res = ReadVarInt64(v);
 		if (res)
 		{
-			a_Value = v;
+			a_Value = static_cast<T>(v);
 		}
 		return res;
 	}
@@ -93,7 +94,8 @@ public:
 	bool WriteBEFloat        (float  a_Value);
 	bool WriteBEDouble       (double a_Value);
 	bool WriteBool           (bool   a_Value);
-	bool WriteVarInt         (UInt32 a_Value);
+	bool WriteVarInt32       (UInt32 a_Value);
+	bool WriteVarInt64       (UInt64 a_Value);
 	bool WriteVarUTF8String  (const AString & a_Value);  // string length as VarInt, then string as UTF-8
 	bool WriteLEInt32        (Int32 a_Value);
 	bool WritePosition64     (Int32 a_BlockX, Int32 a_BlockY, Int32 a_BlockZ);

--- a/src/ByteBuffer.h
+++ b/src/ByteBuffer.h
@@ -52,13 +52,14 @@ public:
 	bool CanWriteBytes(size_t a_Count) const;
 
 	// Read the specified datatype and advance the read pointer; return true if successfully read:
-	bool ReadChar           (char & a_Value);
-	bool ReadByte           (unsigned char & a_Value);
-	bool ReadBEShort        (short & a_Value);
-	bool ReadBEUInt16       (UInt16 & a_Value);
-	bool ReadBEInt          (int & a_Value);
-	bool ReadBEUInt32       (UInt32 & a_Value);
+	bool ReadBEInt8         (Int8 & a_Value);
+	bool ReadBEInt16        (Int16 & a_Value);
+	bool ReadBEInt32        (Int32 & a_Value);
 	bool ReadBEInt64        (Int64 & a_Value);
+	bool ReadBEUInt8        (UInt8 & a_Value);
+	bool ReadBEUInt16       (UInt16 & a_Value);
+	bool ReadBEUInt32       (UInt32 & a_Value);
+	bool ReadBEUInt64       (UInt64 & a_Value);
 	bool ReadBEFloat        (float & a_Value);
 	bool ReadBEDouble       (double & a_Value);
 	bool ReadBool           (bool & a_Value);
@@ -81,19 +82,21 @@ public:
 	}
 
 	// Write the specified datatype; return true if successfully written
-	bool WriteChar           (char a_Value);
-	bool WriteByte           (unsigned char a_Value);
-	bool WriteBEShort        (short  a_Value);
-	bool WriteBEUShort       (unsigned short a_Value);
-	bool WriteBEInt          (int    a_Value);
+	bool WriteBEInt8         (Int8   a_Value);
+	bool WriteBEInt16        (Int16  a_Value);
+	bool WriteBEInt32        (Int32  a_Value);
 	bool WriteBEInt64        (Int64  a_Value);
+	bool WriteBEUInt8        (UInt8  a_Value);
+	bool WriteBEUInt16       (UInt16 a_Value);
+	bool WriteBEUInt32       (UInt32 a_Value);
+	bool WriteBEUInt64       (UInt64 a_Value);
 	bool WriteBEFloat        (float  a_Value);
 	bool WriteBEDouble       (double a_Value);
 	bool WriteBool           (bool   a_Value);
 	bool WriteVarInt         (UInt32 a_Value);
 	bool WriteVarUTF8String  (const AString & a_Value);  // string length as VarInt, then string as UTF-8
-	bool WriteLEInt          (int a_Value);
-	bool WritePosition       (int a_BlockX, int a_BlockY, int a_BlockZ);
+	bool WriteLEInt32        (Int32 a_Value);
+	bool WritePosition       (Int32 a_BlockX, Int32 a_BlockY, Int32 a_BlockZ);
 	
 	/** Reads a_Count bytes into a_Buffer; returns true if successful */
 	bool ReadBuf(void * a_Buffer, size_t a_Count);

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -2814,7 +2814,7 @@ void cChunk::BroadcastBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, char
 
 
 
-void cChunk::BroadcastBlockBreakAnimation(int a_entityID, int a_blockX, int a_blockY, int a_blockZ, char a_stage, const cClientHandle * a_Exclude)
+void cChunk::BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude)
 {
 	for (cClientHandleList::iterator itr = m_LoadedByClient.begin(); itr != m_LoadedByClient.end(); ++itr)
 	{
@@ -2822,7 +2822,7 @@ void cChunk::BroadcastBlockBreakAnimation(int a_entityID, int a_blockX, int a_bl
 		{
 			continue;
 		}
-		(*itr)->SendBlockBreakAnim(a_entityID, a_blockX, a_blockY, a_blockZ, a_stage);
+		(*itr)->SendBlockBreakAnim(a_EntityID, a_BlockX, a_BlockY, a_BlockZ, a_Stage);
 	}  // for itr - LoadedByClient[]
 }
 

--- a/src/Chunk.cpp
+++ b/src/Chunk.cpp
@@ -1969,7 +1969,7 @@ void cChunk::RemoveEntity(cEntity * a_Entity)
 
 
 
-bool cChunk::HasEntity(int a_EntityID)
+bool cChunk::HasEntity(UInt32 a_EntityID)
 {
 	for (cEntityList::const_iterator itr = m_Entities.begin(), end = m_Entities.end(); itr != end; ++itr)
 	{
@@ -2027,7 +2027,7 @@ bool cChunk::ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback & a_
 
 
 
-bool cChunk::DoWithEntityByID(int a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackResult)
+bool cChunk::DoWithEntityByID(UInt32 a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackResult)
 {
 	// The entity list is locked by the parent chunkmap's CS
 	for (cEntityList::iterator itr = m_Entities.begin(), end = m_Entities.end(); itr != end; ++itr)

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -317,7 +317,7 @@ public:
 	// (Please keep these alpha-sorted)
 	void BroadcastAttachEntity       (const cEntity & a_Entity, const cEntity * a_Vehicle);
 	void BroadcastBlockAction        (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType, const cClientHandle * a_Exclude = nullptr);
-	void BroadcastBlockBreakAnimation(int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude = nullptr);
+	void BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastBlockEntity        (int a_BlockX, int a_BlockY, int a_BlockZ, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastChunkData          (cChunkDataSerializer & a_Serializer, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastCollectEntity      (const cEntity & a_Entity, const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);

--- a/src/Chunk.h
+++ b/src/Chunk.h
@@ -241,7 +241,7 @@ public:
 
 	void AddEntity(cEntity * a_Entity);
 	void RemoveEntity(cEntity * a_Entity);
-	bool HasEntity(int a_EntityID);
+	bool HasEntity(UInt32 a_EntityID);
 	
 	/** Calls the callback for each entity; returns true if all entities processed, false if the callback aborted by returning true */
 	bool ForEachEntity(cEntityCallback & a_Callback);  // Lua-accessible
@@ -251,7 +251,7 @@ public:
 	bool ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback & a_Callback);  // Lua-accessible
 
 	/** Calls the callback if the entity with the specified ID is found, with the entity object as the callback param. Returns true if entity found. */
-	bool DoWithEntityByID(int a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackResult);  // Lua-accessible
+	bool DoWithEntityByID(UInt32 a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackResult);  // Lua-accessible
 
 	/** Calls the callback for each block entity; returns true if all block entities processed, false if the callback aborted by returning true */
 	bool ForEachBlockEntity(cBlockEntityCallback & a_Callback);  // Lua-accessible

--- a/src/ChunkMap.cpp
+++ b/src/ChunkMap.cpp
@@ -373,19 +373,19 @@ void cChunkMap::BroadcastBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, c
 
 
 
-void cChunkMap::BroadcastBlockBreakAnimation(int a_entityID, int a_blockX, int a_blockY, int a_blockZ, char a_stage, const cClientHandle * a_Exclude)
+void cChunkMap::BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude)
 {
 	cCSLock Lock(m_CSLayers);
 	int ChunkX, ChunkZ;
 
-	cChunkDef::BlockToChunk(a_blockX, a_blockZ, ChunkX, ChunkZ);
+	cChunkDef::BlockToChunk(a_BlockX, a_BlockZ, ChunkX, ChunkZ);
 	cChunkPtr Chunk = GetChunkNoGen(ChunkX, ChunkZ);
 	if (Chunk == nullptr)
 	{
 		return;
 	}
 	// It's perfectly legal to broadcast packets even to invalid chunks!
-	Chunk->BroadcastBlockBreakAnimation(a_entityID, a_blockX, a_blockY, a_blockZ, a_stage, a_Exclude);
+	Chunk->BroadcastBlockBreakAnimation(a_EntityID, a_BlockX, a_BlockY, a_BlockZ, a_Stage, a_Exclude);
 }
 
 
@@ -1753,7 +1753,7 @@ void cChunkMap::AddEntityIfNotPresent(cEntity * a_Entity)
 
 
 
-bool cChunkMap::HasEntity(int a_UniqueID)
+bool cChunkMap::HasEntity(UInt32 a_UniqueID)
 {
 	cCSLock Lock(m_CSLayers);
 	for (cChunkLayerList::const_iterator itr = m_Layers.begin(); itr != m_Layers.end(); ++itr)
@@ -2045,7 +2045,7 @@ void cChunkMap::DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_
 
 
 
-bool cChunkMap::DoWithEntityByID(int a_UniqueID, cEntityCallback & a_Callback)
+bool cChunkMap::DoWithEntityByID(UInt32 a_UniqueID, cEntityCallback & a_Callback)
 {
 	cCSLock Lock(m_CSLayers);
 	bool res = false;
@@ -2996,7 +2996,7 @@ bool cChunkMap::cChunkLayer::ForEachEntity(cEntityCallback & a_Callback)
 
 
 
-bool cChunkMap::cChunkLayer::DoWithEntityByID(int a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackReturn)
+bool cChunkMap::cChunkLayer::DoWithEntityByID(UInt32 a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackReturn)
 {
 	// Calls the callback if the entity with the specified ID is found, with the entity object as the callback param. Returns true if entity found.
 	for (size_t i = 0; i < ARRAYCOUNT(m_Chunks); i++)
@@ -3016,7 +3016,7 @@ bool cChunkMap::cChunkLayer::DoWithEntityByID(int a_EntityID, cEntityCallback & 
 
 
 
-bool cChunkMap::cChunkLayer::HasEntity(int a_EntityID)
+bool cChunkMap::cChunkLayer::HasEntity(UInt32 a_EntityID)
 {
 	for (size_t i = 0; i < ARRAYCOUNT(m_Chunks); i++)
 	{

--- a/src/ChunkMap.h
+++ b/src/ChunkMap.h
@@ -71,7 +71,7 @@ public:
 	// (Please keep these alpha-sorted)
 	void BroadcastAttachEntity(const cEntity & a_Entity, const cEntity * a_Vehicle);
 	void BroadcastBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType, const cClientHandle * a_Exclude = nullptr);
-	void BroadcastBlockBreakAnimation(int a_entityID, int a_blockX, int a_blockY, int a_blockZ, char a_stage, const cClientHandle * a_Exclude = nullptr);
+	void BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastBlockEntity(int a_BlockX, int a_BlockY, int a_BlockZ, const cClientHandle * a_Exclude);
 	void BroadcastChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerializer & a_Serializer, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastCollectEntity(const cEntity & a_Entity, const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
@@ -217,7 +217,7 @@ public:
 	void AddEntityIfNotPresent(cEntity * a_Entity);
 	
 	/** Returns true if the entity with specified ID is present in the chunks */
-	bool HasEntity(int a_EntityID);
+	bool HasEntity(UInt32 a_EntityID);
 	
 	/** Removes the entity from its appropriate chunk */
 	void RemoveEntity(cEntity * a_Entity);
@@ -236,61 +236,80 @@ public:
 	/** Destroys and returns a list of blocks destroyed in the explosion at the specified coordinates */
 	void DoExplosionAt(double a_ExplosionSize, double a_BlockX, double a_BlockY, double a_BlockZ, cVector3iArray & a_BlockAffected);
 	
-	/** Calls the callback if the entity with the specified ID is found, with the entity object as the callback param. Returns true if entity found and callback returned false. */
-	bool DoWithEntityByID(int a_UniqueID, cEntityCallback & a_Callback);  // Lua-accessible
+	/** Calls the callback if the entity with the specified ID is found, with the entity object as the callback param.
+	Returns true if entity found and callback returned false. */
+	bool DoWithEntityByID(UInt32 a_EntityID, cEntityCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for each block entity in the specified chunk; returns true if all block entities processed, false if the callback aborted by returning true */
+	/** Calls the callback for each block entity in the specified chunk.
+	Returns true if all block entities processed, false if the callback aborted by returning true. */
 	bool ForEachBlockEntityInChunk(int a_ChunkX, int a_ChunkZ, cBlockEntityCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for each chest in the specified chunk; returns true if all chests processed, false if the callback aborted by returning true */
+	/** Calls the callback for each chest in the specified chunk.
+	Returns true if all chests processed, false if the callback aborted by returning true. */
 	bool ForEachChestInChunk(int a_ChunkX, int a_ChunkZ, cChestCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for each dispenser in the specified chunk; returns true if all dispensers processed, false if the callback aborted by returning true */
+	/** Calls the callback for each dispenser in the specified chunk.
+	Returns true if all dispensers processed, false if the callback aborted by returning true. */
 	bool ForEachDispenserInChunk(int a_ChunkX, int a_ChunkZ, cDispenserCallback & a_Callback);
 
-	/** Calls the callback for each dropper in the specified chunk; returns true if all droppers processed, false if the callback aborted by returning true */
+	/** Calls the callback for each dropper in the specified chunk.
+	Returns true if all droppers processed, false if the callback aborted by returning true. */
 	bool ForEachDropperInChunk(int a_ChunkX, int a_ChunkZ, cDropperCallback & a_Callback);
 
-	/** Calls the callback for each dropspenser in the specified chunk; returns true if all dropspensers processed, false if the callback aborted by returning true */
+	/** Calls the callback for each dropspenser in the specified chunk.
+	Returns true if all dropspensers processed, false if the callback aborted by returning true. */
 	bool ForEachDropSpenserInChunk(int a_ChunkX, int a_ChunkZ, cDropSpenserCallback & a_Callback);
 
-	/** Calls the callback for each furnace in the specified chunk; returns true if all furnaces processed, false if the callback aborted by returning true */
+	/** Calls the callback for each furnace in the specified chunk.
+	Returns true if all furnaces processed, false if the callback aborted by returning true. */
 	bool ForEachFurnaceInChunk(int a_ChunkX, int a_ChunkZ, cFurnaceCallback & a_Callback);  // Lua-accessible
 	
-	/** Calls the callback for the block entity at the specified coords; returns false if there's no block entity at those coords, true if found */
+	/** Calls the callback for the block entity at the specified coords.
+	Returns false if there's no block entity at those coords, true if found. */
 	bool DoWithBlockEntityAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBlockEntityCallback & a_Callback);  // Lua-acessible
 
-	/** Calls the callback for the beacon at the specified coords; returns false if there's no beacon at those coords, true if found */
+	/** Calls the callback for the beacon at the specified coords.
+	Returns false if there's no beacon at those coords, true if found. */
 	bool DoWithBeaconAt(int a_BlockX, int a_BlockY, int a_BlockZ, cBeaconCallback & a_Callback);  // Lua-acessible
 
-	/** Calls the callback for the chest at the specified coords; returns false if there's no chest at those coords, true if found */
+	/** Calls the callback for the chest at the specified coords.
+	Returns false if there's no chest at those coords, true if found. */
 	bool DoWithChestAt(int a_BlockX, int a_BlockY, int a_BlockZ, cChestCallback & a_Callback);  // Lua-acessible
 
-	/** Calls the callback for the dispenser at the specified coords; returns false if there's no dispenser at those coords or callback returns true, returns true if found */
+	/** Calls the callback for the dispenser at the specified coords.
+	Returns false if there's no dispenser at those coords or callback returns true, returns true if found. */
 	bool DoWithDispenserAt(int a_BlockX, int a_BlockY, int a_BlockZ, cDispenserCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for the dropper at the specified coords; returns false if there's no dropper at those coords or callback returns true, returns true if found */
+	/** Calls the callback for the dropper at the specified coords.
+	Returns false if there's no dropper at those coords or callback returns true, returns true if found. */
 	bool DoWithDropperAt(int a_BlockX, int a_BlockY, int a_BlockZ, cDropperCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for the dropspenser at the specified coords; returns false if there's no dropspenser at those coords or callback returns true, returns true if found */
+	/** Calls the callback for the dropspenser at the specified coords.
+	Returns false if there's no dropspenser at those coords or callback returns true, returns true if found. */
 	bool DoWithDropSpenserAt(int a_BlockX, int a_BlockY, int a_BlockZ, cDropSpenserCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for the furnace at the specified coords; returns false if there's no furnace at those coords or callback returns true, returns true if found */
+	/** Calls the callback for the furnace at the specified coords.
+	Returns false if there's no furnace at those coords or callback returns true, returns true if found. */
 	bool DoWithFurnaceAt(int a_BlockX, int a_BlockY, int a_BlockZ, cFurnaceCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for the noteblock at the specified coords; returns false if there's no noteblock at those coords or callback returns true, returns true if found */
+	/** Calls the callback for the noteblock at the specified coords.
+	Returns false if there's no noteblock at those coords or callback returns true, returns true if found. */
 	bool DoWithNoteBlockAt(int a_BlockX, int a_BlockY, int a_BlockZ, cNoteBlockCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for the command block at the specified coords; returns false if there's no command block at those coords or callback returns true, returns true if found */
+	/** Calls the callback for the command block at the specified coords.
+	Returns false if there's no command block at those coords or callback returns true, returns true if found. */
 	bool DoWithCommandBlockAt(int a_BlockX, int a_BlockY, int a_BlockZ, cCommandBlockCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for the mob head block at the specified coords; returns false if there's no mob head block at those coords or callback returns true, returns true if found */
+	/** Calls the callback for the mob head block at the specified coords.
+	Returns false if there's no mob head block at those coords or callback returns true, returns true if found. */
 	bool DoWithMobHeadAt(int a_BlockX, int a_BlockY, int a_BlockZ, cMobHeadCallback & a_Callback);  // Lua-accessible
 
-	/** Calls the callback for the flower pot at the specified coords; returns false if there's no flower pot at those coords or callback returns true, returns true if found */
+	/** Calls the callback for the flower pot at the specified coords.
+	Returns false if there's no flower pot at those coords or callback returns true, returns true if found. */
 	bool DoWithFlowerPotAt(int a_BlockX, int a_BlockY, int a_BlockZ, cFlowerPotCallback & a_Callback);  // Lua-accessible
 
-	/** Retrieves the test on the sign at the specified coords; returns false if there's no sign at those coords, true if found */
+	/** Retrieves the test on the sign at the specified coords.
+	Returns false if there's no sign at those coords, true if found. */
 	bool GetSignLines (int a_BlockX, int a_BlockY, int a_BlockZ, AString & a_Line1, AString & a_Line2, AString & a_Line3, AString & a_Line4);  // Lua-accessible
 
 	/** Touches the chunk, causing it to be loaded or generated */
@@ -423,10 +442,10 @@ private:
 		bool ForEachEntity(cEntityCallback & a_Callback);  // Lua-accessible
 
 		/** Calls the callback if the entity with the specified ID is found, with the entity object as the callback param. Returns true if entity found. */
-		bool DoWithEntityByID(int a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackReturn);  // Lua-accessible
+		bool DoWithEntityByID(UInt32 a_EntityID, cEntityCallback & a_Callback, bool & a_CallbackReturn);  // Lua-accessible
 
 		/** Returns true if there is an entity with the specified ID within this layer's chunks */
-		bool HasEntity(int a_EntityID);
+		bool HasEntity(UInt32 a_EntityID);
 		
 	protected:
 	

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -676,7 +676,7 @@ bool cClientHandle::HandleLogin(int a_ProtocolVersion, const AString & a_Usernam
 
 
 
-void cClientHandle::HandleCreativeInventory(short a_SlotNum, const cItem & a_HeldItem)
+void cClientHandle::HandleCreativeInventory(Int16 a_SlotNum, const cItem & a_HeldItem, eClickAction a_ClickAction)
 {
 	// This is for creative Inventory changes
 	if (!m_Player->IsGameModeCreative())
@@ -690,18 +690,18 @@ void cClientHandle::HandleCreativeInventory(short a_SlotNum, const cItem & a_Hel
 		return;
 	}
 	
-	m_Player->GetWindow()->Clicked(*m_Player, 0, a_SlotNum, (a_SlotNum >= 0) ? caLeftClick : caLeftClickOutside, a_HeldItem);
+	m_Player->GetWindow()->Clicked(*m_Player, 0, a_SlotNum, a_ClickAction, a_HeldItem);
 }
 
 
 
 
 
-void cClientHandle::HandleEnchantItem(Byte a_WindowID, Byte a_Enchantment)
+void cClientHandle::HandleEnchantItem(UInt8 a_WindowID, UInt8 a_Enchantment)
 {
 	if (a_Enchantment > 2)
 	{
-		LOGWARNING("%s attempt to crash the server with invalid enchanting selection!", GetUsername().c_str());
+		LOGWARNING("%s attempt to crash the server with invalid enchanting selection (%u)!", GetUsername().c_str(), a_Enchantment);
 		Kick("Invalid enchanting!");
 		return;
 	}
@@ -951,7 +951,7 @@ void cClientHandle::HandleCommandBlockBlockChange(int a_BlockX, int a_BlockY, in
 
 
 
-void cClientHandle::HandleCommandBlockEntityChange(int a_EntityID, const AString & a_NewCommand)
+void cClientHandle::HandleCommandBlockEntityChange(UInt32 a_EntityID, const AString & a_NewCommand)
 {
 	// TODO
 	LOGWARNING("%s: Not implemented yet", __FUNCTION__);
@@ -1509,7 +1509,7 @@ void cClientHandle::HandleAnimation(int a_Animation)
 
 
 
-void cClientHandle::HandleSlotSelected(short a_SlotNum)
+void cClientHandle::HandleSlotSelected(Int16 a_SlotNum)
 {
 	m_Player->GetInventory().SetEquippedSlotNum(a_SlotNum);
 	m_Player->GetWorld()->BroadcastEntityEquipment(*m_Player, 0, m_Player->GetInventory().GetEquippedItem(), this);
@@ -1528,7 +1528,7 @@ void cClientHandle::HandleSteerVehicle(float a_Forward, float a_Sideways)
 
 
 
-void cClientHandle::HandleWindowClose(char a_WindowID)
+void cClientHandle::HandleWindowClose(UInt8 a_WindowID)
 {
 	m_Player->CloseWindowIfID(a_WindowID);
 }
@@ -1537,7 +1537,7 @@ void cClientHandle::HandleWindowClose(char a_WindowID)
 
 
 
-void cClientHandle::HandleWindowClick(char a_WindowID, short a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem)
+void cClientHandle::HandleWindowClick(UInt8 a_WindowID, Int16 a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem)
 {
 	LOGD("WindowClick: WinID %d, SlotNum %d, action: %s, Item %s x %d",
 		a_WindowID, a_SlotNum, ClickActionToString(a_ClickAction),
@@ -1575,7 +1575,7 @@ void cClientHandle::HandleUpdateSign(
 
 
 
-void cClientHandle::HandleUseEntity(int a_TargetEntityID, bool a_IsLeftClick)
+void cClientHandle::HandleUseEntity(UInt32 a_TargetEntityID, bool a_IsLeftClick)
 {
 	// TODO: Let plugins interfere via a hook
 	
@@ -1720,7 +1720,7 @@ bool cClientHandle::HandleHandshake(const AString & a_Username)
 
 
 
-void cClientHandle::HandleEntityCrouch(int a_EntityID, bool a_IsCrouching)
+void cClientHandle::HandleEntityCrouch(UInt32 a_EntityID, bool a_IsCrouching)
 {
 	if (a_EntityID != m_Player->GetUniqueID())
 	{
@@ -1735,7 +1735,7 @@ void cClientHandle::HandleEntityCrouch(int a_EntityID, bool a_IsCrouching)
 
 
 
-void cClientHandle::HandleEntityLeaveBed(int a_EntityID)
+void cClientHandle::HandleEntityLeaveBed(UInt32 a_EntityID)
 {
 	if (a_EntityID != m_Player->GetUniqueID())
 	{
@@ -1752,7 +1752,7 @@ void cClientHandle::HandleEntityLeaveBed(int a_EntityID)
 
 
 
-void cClientHandle::HandleEntitySprinting(int a_EntityID, bool a_IsSprinting)
+void cClientHandle::HandleEntitySprinting(UInt32 a_EntityID, bool a_IsSprinting)
 {
 	if (a_EntityID != m_Player->GetUniqueID())
 	{

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -978,7 +978,7 @@ void cClientHandle::HandleAnvilItemName(const AString & a_ItemName)
 
 
 
-void cClientHandle::HandleLeftClick(int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, char a_Status)
+void cClientHandle::HandleLeftClick(int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, UInt8 a_Status)
 {
 	LOGD("HandleLeftClick: {%i, %i, %i}; Face: %i; Stat: %i",
 		a_BlockX, a_BlockY, a_BlockZ, a_BlockFace, a_Status

--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -2024,7 +2024,7 @@ void cClientHandle::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, ch
 
 
 
-void cClientHandle::SendBlockBreakAnim(int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
+void cClientHandle::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
 {
 	m_Protocol->SendBlockBreakAnim(a_EntityID, a_BlockX, a_BlockY, a_BlockZ, a_Stage);
 }

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -300,7 +300,7 @@ public:  // tolua_export
 	bool HandleHandshake        (const AString & a_Username);
 	
 	void HandleKeepAlive        (int a_KeepAliveID);
-	void HandleLeftClick        (int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, char a_Status);
+	void HandleLeftClick        (int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, UInt8 a_Status);
 	
 	/** Called when the protocol receives a MC|TrSel packet, indicating that the player used a trade in
 	the NPC UI. */

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -144,7 +144,7 @@ public:  // tolua_export
 	// (Please keep these alpha-sorted)
 	void SendAttachEntity               (const cEntity & a_Entity, const cEntity * a_Vehicle);
 	void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType);
-	void SendBlockBreakAnim             (int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage);
+	void SendBlockBreakAnim             (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage);
 	void SendBlockChange                (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta);  // tolua_export
 	void SendBlockChanges               (int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes);
 	void SendChat                       (const AString & a_Message, eMessageType a_ChatPrefix, const AString & a_AdditionalData = "");

--- a/src/ClientHandle.h
+++ b/src/ClientHandle.h
@@ -276,16 +276,18 @@ public:  // tolua_export
 	
 	/** Called when the protocol receives a MC|AdvCdm plugin message, indicating that the player set a new
 	command in the command block UI, for an entity-based commandblock (minecart?). */
-	void HandleCommandBlockEntityChange(int a_EntityID, const AString & a_NewCommand);
+	void HandleCommandBlockEntityChange(UInt32 a_EntityID, const AString & a_NewCommand);
 	
-	void HandleCreativeInventory      (short a_SlotNum, const cItem & a_HeldItem);
+	/** Called when the client clicks the creative inventory window.
+	a_ClickAction specifies whether the click was inside the window or not (caLeftClick or caLeftClickOutside). */
+	void HandleCreativeInventory(Int16 a_SlotNum, const cItem & a_HeldItem, eClickAction a_ClickAction);
 
 	/** Called when the player enchants an Item in the Enchanting table UI. */
-	void HandleEnchantItem(Byte a_WindowID, Byte a_Enchantment);
+	void HandleEnchantItem(UInt8 a_WindowID, UInt8 a_Enchantment);
 
-	void HandleEntityCrouch           (int a_EntityID, bool a_IsCrouching);
-	void HandleEntityLeaveBed         (int a_EntityID);
-	void HandleEntitySprinting        (int a_EntityID, bool a_IsSprinting);
+	void HandleEntityCrouch           (UInt32 a_EntityID, bool a_IsCrouching);
+	void HandleEntityLeaveBed         (UInt32 a_EntityID);
+	void HandleEntitySprinting        (UInt32 a_EntityID, bool a_IsSprinting);
 	
 	/** Kicks the client if the same username is already logged in.
 	Returns false if the client has been kicked, true otherwise. */
@@ -312,7 +314,7 @@ public:  // tolua_export
 	void HandlePluginMessage    (const AString & a_Channel, const AString & a_Message);
 	void HandleRespawn          (void);
 	void HandleRightClick       (int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace, int a_CursorX, int a_CursorY, int a_CursorZ, const cItem & a_HeldItem);
-	void HandleSlotSelected     (short a_SlotNum);
+	void HandleSlotSelected     (Int16 a_SlotNum);
 	void HandleSteerVehicle     (float Forward, float Sideways);
 	void HandleTabCompletion    (const AString & a_Text);
 	void HandleUpdateSign       (
@@ -321,9 +323,9 @@ public:  // tolua_export
 		const AString & a_Line3, const AString & a_Line4
 	);
 	void HandleUnmount          (void);
-	void HandleUseEntity        (int a_TargetEntityID, bool a_IsLeftClick);
-	void HandleWindowClick      (char a_WindowID, short a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem);
-	void HandleWindowClose      (char a_WindowID);
+	void HandleUseEntity        (UInt32 a_TargetEntityID, bool a_IsLeftClick);
+	void HandleWindowClick      (UInt8 a_WindowID, Int16 a_SlotNum, eClickAction a_ClickAction, const cItem & a_HeldItem);
+	void HandleWindowClose      (UInt8 a_WindowID);
 
 	/** Called when the protocol has finished logging the user in.
 	Return true to allow the user in; false to kick them.

--- a/src/Endianness.h
+++ b/src/Endianness.h
@@ -59,6 +59,18 @@ inline Int64 NetworkToHostLong8(const void * a_Value)
 
 
 
+inline UInt64 NetworkToHostULong8(const void * a_Value)
+{
+	UInt64 buf;
+	memcpy(&buf, a_Value, 8);
+	buf = ntohll(buf);
+	return buf;
+}
+
+
+
+
+
 inline float NetworkToHostFloat4(const void * a_Value)
 {
 	UInt32 buf;

--- a/src/Entities/Entity.cpp
+++ b/src/Entities/Entity.cpp
@@ -18,49 +18,50 @@
 
 
 
-int cEntity::m_EntityCount = 0;
+UInt32 cEntity::m_EntityCount = 0;
 cCriticalSection cEntity::m_CSCount;
 
 
 
 
 
-cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, double a_Width, double a_Height)
-	: m_UniqueID(0)
-	, m_Health(1)
-	, m_MaxHealth(1)
-	, m_AttachedTo(nullptr)
-	, m_Attachee(nullptr)
-	, m_bDirtyHead(true)
-	, m_bDirtyOrientation(true)
-	, m_bHasSentNoSpeed(true)
-	, m_bOnGround(false)
-	, m_Gravity(-9.81f)
-	, m_LastPos(a_X, a_Y, a_Z)
-	, m_IsInitialized(false)
-	, m_WorldTravellingFrom(nullptr)
-	, m_EntityType(a_EntityType)
-	, m_World(nullptr)
-	, m_IsFireproof(false)
-	, m_TicksSinceLastBurnDamage(0)
-	, m_TicksSinceLastLavaDamage(0)
-	, m_TicksSinceLastFireDamage(0)
-	, m_TicksLeftBurning(0)
-	, m_TicksSinceLastVoidDamage(0)
-	, m_IsSwimming(false)
-	, m_IsSubmerged(false)
-	, m_AirLevel(0)
-	, m_AirTickTimer(0)
-	, m_TicksAlive(0)
-	, m_HeadYaw(0.0)
-	, m_Rot(0.0, 0.0, 0.0)
-	, m_Pos(a_X, a_Y, a_Z)
-	, m_WaterSpeed(0, 0, 0)
-	, m_Mass (0.001)  // Default 1g
-	, m_Width(a_Width)
-	, m_Height(a_Height)
-	, m_InvulnerableTicks(0)
+cEntity::cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, double a_Width, double a_Height):
+	m_UniqueID(INVALID_ID),  // Proper ID will be assigned later in the constructor code
+	m_Health(1),
+	m_MaxHealth(1),
+	m_AttachedTo(nullptr),
+	m_Attachee(nullptr),
+	m_bDirtyHead(true),
+	m_bDirtyOrientation(true),
+	m_bHasSentNoSpeed(true),
+	m_bOnGround(false),
+	m_Gravity(-9.81f),
+	m_LastPos(a_X, a_Y, a_Z),
+	m_IsInitialized(false),
+	m_WorldTravellingFrom(nullptr),
+	m_EntityType(a_EntityType),
+	m_World(nullptr),
+	m_IsFireproof(false),
+	m_TicksSinceLastBurnDamage(0),
+	m_TicksSinceLastLavaDamage(0),
+	m_TicksSinceLastFireDamage(0),
+	m_TicksLeftBurning(0),
+	m_TicksSinceLastVoidDamage(0),
+	m_IsSwimming(false),
+	m_IsSubmerged(false),
+	m_AirLevel(0),
+	m_AirTickTimer(0),
+	m_TicksAlive(0),
+	m_HeadYaw(0.0),
+	m_Rot(0.0, 0.0, 0.0),
+	m_Pos(a_X, a_Y, a_Z),
+	m_WaterSpeed(0, 0, 0),
+	m_Mass (0.001),  // Default 1g
+	m_Width(a_Width),
+	m_Height(a_Height),
+	m_InvulnerableTicks(0)
 {
+	// Assign a proper ID:
 	cCSLock Lock(m_CSCount);
 	m_EntityCount++;
 	m_UniqueID = m_EntityCount;

--- a/src/Entities/Entity.h
+++ b/src/Entities/Entity.h
@@ -142,6 +142,10 @@ public:
 	
 	static const int VOID_BOUNDARY         = -46;  ///< Y position to begin applying void damage
 	static const int FALL_DAMAGE_HEIGHT    = 4;    ///< Y difference after which fall damage is applied
+
+	/** Special ID that is considered an "invalid value", signifying no entity. */
+	static const UInt32 INVALID_ID = 0;  // Exported to Lua in ManualBindings.cpp, ToLua doesn't parse initialized constants.
+
 	
 	cEntity(eEntityType a_EntityType, double a_X, double a_Y, double a_Z, double a_Width, double a_Height);
 	virtual ~cEntity();
@@ -248,7 +252,7 @@ public:
 	virtual void HandleSpeedFromAttachee(float a_Forward, float a_Sideways);
 	void SteerVehicle(float a_Forward, float a_Sideways);
 
-	inline int  GetUniqueID(void) const { return m_UniqueID; }
+	inline UInt32 GetUniqueID(void) const { return m_UniqueID; }
 	inline bool IsDestroyed(void) const { return !m_IsInitialized; }
 
 	/// Schedules the entity for destroying; if a_ShouldBroadcast is set to true, broadcasts the DestroyEntity packet
@@ -464,12 +468,15 @@ public:
 
 protected:
 	static cCriticalSection m_CSCount;
-	static int m_EntityCount;
+	static UInt32 m_EntityCount;
 	
 	/** Measured in meter/second (m/s) */
 	Vector3d m_Speed;
 
-	int m_UniqueID;
+	/** The ID of the entity that is guaranteed to be unique within a single run of the server.
+	Always nonzero (a zero UniqueID (cEntity::INVALID_ID) is used for error reporting).
+	Note that the UniqueID is not persisted through storage. */
+	UInt32 m_UniqueID;
 	
 	int m_Health;
 	int m_MaxHealth;

--- a/src/Entities/ItemFrame.h
+++ b/src/Entities/ItemFrame.h
@@ -24,7 +24,7 @@ public:
 	// tolua_begin
 
 	/** Returns the item in the frame */
-	const cItem & GetItem(void) { return m_Item; }
+	const cItem & GetItem(void) const { return m_Item; }
 
 	/** Set the item in the frame */
 	void SetItem(cItem & a_Item) { m_Item = a_Item; }

--- a/src/Entities/Minecart.cpp
+++ b/src/Entities/Minecart.cpp
@@ -24,7 +24,7 @@ class cMinecartCollisionCallback :
 	public cEntityCallback
 {
 public:
-	cMinecartCollisionCallback(Vector3d a_Pos, double a_Height, double a_Width, int a_UniqueID, int a_AttacheeUniqueID) :
+	cMinecartCollisionCallback(Vector3d a_Pos, double a_Height, double a_Width, UInt32 a_UniqueID, UInt32 a_AttacheeUniqueID) :
 		m_DoesInteserct(false),
 		m_CollidedEntityPos(0, 0, 0),
 		m_Pos(a_Pos),
@@ -77,8 +77,8 @@ protected:
 
 	Vector3d m_Pos;
 	double m_Height, m_Width;
-	int m_UniqueID;
-	int m_AttacheeUniqueID;
+	UInt32 m_UniqueID;
+	UInt32 m_AttacheeUniqueID;
 };
 
 
@@ -824,7 +824,10 @@ bool cMinecart::TestBlockCollision(NIBBLETYPE a_RailMeta)
 
 bool cMinecart::TestEntityCollision(NIBBLETYPE a_RailMeta)
 {
-	cMinecartCollisionCallback MinecartCollisionCallback(GetPosition(), GetHeight(), GetWidth(), GetUniqueID(), ((m_Attachee == nullptr) ? -1 : m_Attachee->GetUniqueID()));
+	cMinecartCollisionCallback MinecartCollisionCallback(
+		GetPosition(), GetHeight(), GetWidth(), GetUniqueID(),
+		((m_Attachee == nullptr) ? cEntity::INVALID_ID : m_Attachee->GetUniqueID())
+	);
 	int ChunkX, ChunkZ;
 	cChunkDef::BlockToChunk(POSX_TOINT, POSZ_TOINT, ChunkX, ChunkZ);
 	m_World->ForEachEntityInChunk(ChunkX, ChunkZ, MinecartCollisionCallback);

--- a/src/Entities/ProjectileEntity.cpp
+++ b/src/Entities/ProjectileEntity.cpp
@@ -221,7 +221,7 @@ cProjectileEntity::cProjectileEntity(eKind a_Kind, cEntity * a_Creator, double a
 	super(etProjectile, a_X, a_Y, a_Z, a_Width, a_Height),
 	m_ProjectileKind(a_Kind),
 	m_CreatorData(
-		((a_Creator != nullptr) ? a_Creator->GetUniqueID() : -1),
+		((a_Creator != nullptr) ? a_Creator->GetUniqueID() : cEntity::INVALID_ID),
 		((a_Creator != nullptr) ? (a_Creator->IsPlayer() ? ((cPlayer *)a_Creator)->GetName() : "") : ""),
 		((a_Creator != nullptr) ? a_Creator->GetEquippedWeapon().m_Enchantments : cEnchantments())
 	),

--- a/src/Entities/ProjectileEntity.h
+++ b/src/Entities/ProjectileEntity.h
@@ -69,7 +69,7 @@ public:
 	/** Returns the unique ID of the entity who created this projectile
 	May return an ID <0
 	*/
-	int GetCreatorUniqueID(void) { return m_CreatorData.m_UniqueID; }
+	UInt32 GetCreatorUniqueID(void) { return m_CreatorData.m_UniqueID; }
 
 	/** Returns the name of the player that created the projectile
 	Will be empty for non-player creators
@@ -90,18 +90,17 @@ public:
 protected:
 
 	/** A structure that stores the Entity ID and Playername of the projectile's creator
-	Used to migitate invalid pointers caused by the creator being destroyed
-	*/
+	Used to migitate invalid pointers caused by the creator being destroyed. */
 	struct CreatorData
 	{
-		CreatorData(int a_UniqueID, const AString & a_Name, const cEnchantments & a_Enchantments) :
+		CreatorData(UInt32 a_UniqueID, const AString & a_Name, const cEnchantments & a_Enchantments) :
 			m_UniqueID(a_UniqueID),
 			m_Name(a_Name),
 			m_Enchantments(a_Enchantments)
 		{
 		}
 
-		const int m_UniqueID;
+		const UInt32 m_UniqueID;
 		AString m_Name;
 		cEnchantments m_Enchantments;
 	};
@@ -110,8 +109,7 @@ protected:
 	eKind m_ProjectileKind;
 	
 	/** The structure for containing the entity ID and name who has created this projectile
-	The ID and/or name may be nullptr (e.g. for dispensers/mobs)
-	*/
+	The ID and/or name may be nullptr (e.g. for dispensers/mobs). */
 	CreatorData m_CreatorData;
 	
 	/** True if the projectile has hit the ground and is stuck there */

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -132,13 +132,15 @@
 
 
 // Integral types with predefined sizes:
-typedef long long Int64;
-typedef int       Int32;
-typedef short     Int16;
+typedef signed long long Int64;
+typedef signed int       Int32;
+typedef signed short     Int16;
+typedef signed char      Int8;
 
 typedef unsigned long long UInt64;
 typedef unsigned int       UInt32;
 typedef unsigned short     UInt16;
+typedef unsigned char      UInt8;
 
 typedef unsigned char Byte;
 
@@ -156,10 +158,12 @@ class SizeChecker<T, Size, true>
 template class SizeChecker<Int64, 8>;
 template class SizeChecker<Int32, 4>;
 template class SizeChecker<Int16, 2>;
+template class SizeChecker<Int8,  1>;
 
 template class SizeChecker<UInt64, 8>;
 template class SizeChecker<UInt32, 4>;
 template class SizeChecker<UInt16, 2>;
+template class SizeChecker<UInt8,  1>;
 
 // A macro to disallow the copy constructor and operator = functions
 // This should be used in the private: declarations for any class that shouldn't allow copying itself

--- a/src/Items/ItemPotion.h
+++ b/src/Items/ItemPotion.h
@@ -39,7 +39,7 @@ public:
 		Vector3d Pos = a_Player->GetThrowStartPos();
 		Vector3d Speed = a_Player->GetLookVector() * 7;
 		
-		if (a_World->CreateProjectile(Pos.x, Pos.y, Pos.z, cProjectileEntity::pkSplashPotion, a_Player, &a_Player->GetEquippedItem(), &Speed) < 0)
+		if (a_World->CreateProjectile(Pos.x, Pos.y, Pos.z, cProjectileEntity::pkSplashPotion, a_Player, &a_Player->GetEquippedItem(), &Speed) == cEntity::INVALID_ID)
 		{
 			return false;
 		}

--- a/src/Items/ItemSpawnEgg.h
+++ b/src/Items/ItemSpawnEgg.h
@@ -36,7 +36,7 @@ public:
 		eMonsterType MonsterType = ItemDamageToMonsterType(a_Item.m_ItemDamage);
 		if (
 			(MonsterType != mtInvalidType) &&  // Valid monster type
-			(a_World->SpawnMob(a_BlockX + 0.5, a_BlockY, a_BlockZ + 0.5, MonsterType) >= 0))  // Spawning succeeded
+			(a_World->SpawnMob(a_BlockX + 0.5, a_BlockY, a_BlockZ + 0.5, MonsterType) != cEntity::INVALID_ID))  // Spawning succeeded
 		{
 			if (!a_Player->IsGameModeCreative())
 			{

--- a/src/Items/ItemThrowable.h
+++ b/src/Items/ItemThrowable.h
@@ -35,7 +35,7 @@ public:
 		cFastRandom Random;
 		a_World->BroadcastSoundEffect("random.bow", a_Player->GetPosX(), a_Player->GetPosY() - a_Player->GetHeight(), a_Player->GetPosZ(), 0.5f, 0.4f / (Random.NextFloat(1.0f) * 0.4f + 0.8f));
 
-		if (a_World->CreateProjectile(Pos.x, Pos.y, Pos.z, m_ProjectileKind, a_Player, &a_Player->GetEquippedItem(), &Speed) < 0)
+		if (a_World->CreateProjectile(Pos.x, Pos.y, Pos.z, m_ProjectileKind, a_Player, &a_Player->GetEquippedItem(), &Speed) == cEntity::INVALID_ID)
 		{
 			return false;
 		}
@@ -135,7 +135,7 @@ public:
 			return false;
 		}
 
-		if (a_World->CreateProjectile(a_BlockX + 0.5, a_BlockY + 1, a_BlockZ + 0.5, m_ProjectileKind, a_Player, &a_Player->GetEquippedItem()) < 0)
+		if (a_World->CreateProjectile(a_BlockX + 0.5, a_BlockY + 1, a_BlockZ + 0.5, m_ProjectileKind, a_Player, &a_Player->GetEquippedItem()) == 0)
 		{
 			return false;
 		}

--- a/src/LoggerListeners.h
+++ b/src/LoggerListeners.h
@@ -1,5 +1,6 @@
 
 #include "Logger.h"
+#include "OSSupport/File.h"
 
 
 

--- a/src/MapManager.cpp
+++ b/src/MapManager.cpp
@@ -22,7 +22,7 @@ cMapManager::cMapManager(cWorld * a_World)
 
 
 
-bool cMapManager::DoWithMap(int a_ID, cMapCallback & a_Callback)
+bool cMapManager::DoWithMap(UInt32 a_ID, cMapCallback & a_Callback)
 {
 	cCSLock Lock(m_CS);
 	cMap * Map = GetMapData(a_ID);

--- a/src/MapManager.h
+++ b/src/MapManager.h
@@ -32,8 +32,7 @@ public:
 	cMapManager(cWorld * a_World);
 
 	/** Returns the map with the specified ID, nullptr if out of range.
-	WARNING: The returned map object is not thread safe.
-	*/
+	WARNING: The returned map object is not thread safe. */
 	cMap * GetMapData(unsigned int a_ID);
 
 	/** Creates a new map. Returns nullptr on error */
@@ -41,13 +40,11 @@ public:
 
 	/** Calls the callback for the map with the specified ID.
 	Returns true if the map was found and the callback called, false if map not found.
-	Callback return value is ignored.
-	*/
-	bool DoWithMap(int a_ID, cMapCallback & a_Callback);  // Exported in ManualBindings.cpp
+	Callback return value is ignored. */
+	bool DoWithMap(UInt32 a_ID, cMapCallback & a_Callback);  // Exported in ManualBindings.cpp
 
 	/** Calls the callback for each map.
-	Returns true if all maps processed, false if the callback aborted by returning true.
-	*/
+	Returns true if all maps processed, false if the callback aborted by returning true. */
 	bool ForEachMap(cMapCallback & a_Callback);
 
 	size_t GetNumMaps(void) const;  // tolua_export

--- a/src/Mobs/Creeper.cpp
+++ b/src/Mobs/Creeper.cpp
@@ -67,30 +67,29 @@ void cCreeper::GetDrops(cItems & a_Drops, cEntity * a_Killer)
 	}
 	AddRandomDropItem(a_Drops, 0, 2 + LootingLevel, E_ITEM_GUNPOWDER);
 
-	if ((a_Killer != nullptr) && a_Killer->IsProjectile() && (((cProjectileEntity *)a_Killer)->GetCreatorUniqueID() >= 0))
+	// If the creeper was killed by a skeleton, add a random music disc drop:
+	if (
+		(a_Killer != nullptr) &&
+		a_Killer->IsProjectile() &&
+		((reinterpret_cast<cProjectileEntity *>(a_Killer))->GetCreatorUniqueID() != cEntity::INVALID_ID))
 	{
 		class cProjectileCreatorCallback : public cEntityCallback
 		{
 		public:
-			cProjectileCreatorCallback(void)
-			{
-			}
+			cProjectileCreatorCallback(void) {}
 
 			virtual bool Item(cEntity * a_Entity) override
 			{
-				if (a_Entity->IsMob() && ((cMonster *)a_Entity)->GetMobType() == mtSkeleton)
+				if (a_Entity->IsMob() && ((reinterpret_cast<cMonster *>(a_Entity))->GetMobType() == mtSkeleton))
 				{
 					return true;
 				}
 				return false;
 			}
-		};
-
-		cProjectileCreatorCallback PCC;
-		if (GetWorld()->DoWithEntityByID(((cProjectileEntity *)a_Killer)->GetCreatorUniqueID(), PCC))
+		} PCC;
+		if (GetWorld()->DoWithEntityByID((reinterpret_cast<cProjectileEntity *>(a_Killer))->GetCreatorUniqueID(), PCC))
 		{
-			// 12 music discs. TickRand starts from 0 to 11. Disk IDs start at 2256, so add that. There.
-			AddRandomDropItem(a_Drops, 1, 1, (short)m_World->GetTickRandomNumber(11) + 2256);
+			AddRandomDropItem(a_Drops, 1, 1, static_cast<short>(m_World->GetTickRandomNumber(11) + E_ITEM_FIRST_DISC));
 		}
 	}
 }

--- a/src/OSSupport/CriticalSection.h
+++ b/src/OSSupport/CriticalSection.h
@@ -10,22 +10,22 @@
 class cCriticalSection
 {
 public:
-
 	void Lock(void);
 	void Unlock(void);
 	
 	// IsLocked/IsLockedByCurrentThread are only used in ASSERT statements, but because of the changes with ASSERT they must always be defined
 	// The fake versions (in Release) will not effect the program in any way
 	#ifdef _DEBUG
-	cCriticalSection(void);
-	bool IsLocked(void);
-	bool IsLockedByCurrentThread(void);
+		cCriticalSection(void);
+		bool IsLocked(void);
+		bool IsLockedByCurrentThread(void);
 	#else
-	bool IsLocked(void) { return false; }
-	bool IsLockedByCurrentThread(void) { return false; }
+		bool IsLocked(void) { return false; }
+		bool IsLockedByCurrentThread(void) { return false; }
 	#endif  // _DEBUG
 	
 private:
+
 	#ifdef _DEBUG
 	int           m_IsLocked;  // Number of times this CS is locked
 	std::thread::id m_OwningThreadID;

--- a/src/Protocol/CMakeLists.txt
+++ b/src/Protocol/CMakeLists.txt
@@ -8,19 +8,23 @@ SET (SRCS
 	Authenticator.cpp
 	ChunkDataSerializer.cpp
 	MojangAPI.cpp
+	Packetizer.cpp
 	Protocol17x.cpp
 	Protocol18x.cpp
-	ProtocolRecognizer.cpp)
+	ProtocolRecognizer.cpp
+)
 
 SET (HDRS
 	Authenticator.h
 	ChunkDataSerializer.h
 	MojangAPI.h
+	Packetizer.h
 	Protocol.h
 	Protocol17x.h
 	Protocol18x.h
-	ProtocolRecognizer.h)
+	ProtocolRecognizer.h
+)
 
-if(NOT MSVC)
+if (NOT MSVC)
 	add_library(Protocol ${SRCS} ${HDRS})
 endif()

--- a/src/Protocol/ChunkDataSerializer.cpp
+++ b/src/Protocol/ChunkDataSerializer.cpp
@@ -188,10 +188,10 @@ void cChunkDataSerializer::Serialize47(AString & a_Data, int a_ChunkX, int a_Chu
 	// Create the packet:
 	cByteBuffer Packet(512 KiB);
 	Packet.WriteVarInt(0x21);  // Packet id (Chunk Data packet)
-	Packet.WriteBEInt(a_ChunkX);
-	Packet.WriteBEInt(a_ChunkZ);
-	Packet.WriteBool(true);  // "Ground-up continuous", or rather, "biome data present" flag
-	Packet.WriteBEUShort(0xffff);  // We're aways sending the full chunk with no additional data, so the bitmap is 0xffff
+	Packet.WriteBEInt32(a_ChunkX);
+	Packet.WriteBEInt32(a_ChunkZ);
+	Packet.WriteBool(true);        // "Ground-up continuous", or rather, "biome data present" flag
+	Packet.WriteBEUInt16(0xffff);  // We're aways sending the full chunk with no additional data, so the bitmap is 0xffff
 
 	// Write the chunk size:
 	const int BiomeDataSize = cChunkDef::Width * cChunkDef::Width;
@@ -208,8 +208,8 @@ void cChunkDataSerializer::Serialize47(AString & a_Data, int a_ChunkX, int a_Chu
 	{
 		BLOCKTYPE BlockType = m_BlockTypes[Index] & 0xFF;
 		NIBBLETYPE BlockMeta = m_BlockMetas[Index / 2] >> ((Index & 1) * 4) & 0x0f;
-		Packet.WriteByte((unsigned char)(BlockType << 4) | BlockMeta);
-		Packet.WriteByte((unsigned char)(BlockType >> 4));
+		Packet.WriteBEUInt8(static_cast<unsigned char>(BlockType << 4) | BlockMeta);
+		Packet.WriteBEUInt8(static_cast<unsigned char>(BlockType >> 4));
 	}
 
 	// Write the rest:

--- a/src/Protocol/ChunkDataSerializer.cpp
+++ b/src/Protocol/ChunkDataSerializer.cpp
@@ -187,7 +187,7 @@ void cChunkDataSerializer::Serialize47(AString & a_Data, int a_ChunkX, int a_Chu
 
 	// Create the packet:
 	cByteBuffer Packet(512 KiB);
-	Packet.WriteVarInt(0x21);  // Packet id (Chunk Data packet)
+	Packet.WriteVarInt32(0x21);  // Packet id (Chunk Data packet)
 	Packet.WriteBEInt32(a_ChunkX);
 	Packet.WriteBEInt32(a_ChunkZ);
 	Packet.WriteBool(true);        // "Ground-up continuous", or rather, "biome data present" flag
@@ -201,7 +201,7 @@ void cChunkDataSerializer::Serialize47(AString & a_Data, int a_ChunkX, int a_Chu
 		sizeof(m_BlockSkyLight) +     // Block sky light
 		BiomeDataSize                 // Biome data
 	);
-	Packet.WriteVarInt(ChunkSize);
+	Packet.WriteVarInt32(ChunkSize);
 
 	// Write the block types to the packet:
 	for (size_t Index = 0; Index < cChunkDef::NumBlocks; Index++)
@@ -234,8 +234,8 @@ void cChunkDataSerializer::Serialize47(AString & a_Data, int a_ChunkX, int a_Chu
 	else
 	{
 		AString PostData;
-		Buffer.WriteVarInt((UInt32)Packet.GetUsedSpace() + 1);
-		Buffer.WriteVarInt(0);
+		Buffer.WriteVarInt32(static_cast<UInt32>(Packet.GetUsedSpace() + 1));
+		Buffer.WriteVarInt32(0);
 		Buffer.ReadAll(PostData);
 		Buffer.CommitRead();
 

--- a/src/Protocol/Packetizer.cpp
+++ b/src/Protocol/Packetizer.cpp
@@ -64,7 +64,7 @@ cPacketizer::~cPacketizer()
 
 void cPacketizer::WriteByteAngle(double a_Angle)
 {
-	WriteChar(static_cast<char>(255 * a_Angle / 360));
+	WriteBEInt8(static_cast<Int8>(255 * a_Angle / 360));
 }
 
 
@@ -73,8 +73,7 @@ void cPacketizer::WriteByteAngle(double a_Angle)
 
 void cPacketizer::WriteFPInt(double a_Value)
 {
-	Int32 Value = static_cast<Int32>(a_Value * 32);
-	WriteInt(Value);
+	WriteBEInt32(static_cast<Int32>(a_Value * 32));
 }
 
 

--- a/src/Protocol/Packetizer.cpp
+++ b/src/Protocol/Packetizer.cpp
@@ -1,0 +1,102 @@
+
+// Packetizer.cpp
+
+// Implements the cPacketizer class representing a wrapper for sending a single packet over a protocol.
+
+#include "Globals.h"
+#include "Packetizer.h"
+
+
+
+
+
+/** Converts the hex digit character to its value. */
+static UInt8 HexDigitValue(char a_Character)
+{
+	switch (a_Character)
+	{
+		case '0': return 0;
+		case '1': return 1;
+		case '2': return 2;
+		case '3': return 3;
+		case '4': return 4;
+		case '5': return 5;
+		case '6': return 6;
+		case '7': return 7;
+		case '8': return 8;
+		case '9': return 9;
+		case 'a': return 10;
+		case 'b': return 11;
+		case 'c': return 12;
+		case 'd': return 13;
+		case 'e': return 14;
+		case 'f': return 15;
+		case 'A': return 10;
+		case 'B': return 11;
+		case 'C': return 12;
+		case 'D': return 13;
+		case 'E': return 14;
+		case 'F': return 15;
+		default:
+		{
+			LOGWARNING("Bad hex digit: %c", a_Character);
+			ASSERT(!"Bad hex digit");
+			return 0;
+		}
+	}
+}
+
+
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// cPacketizer:
+
+cPacketizer::~cPacketizer()
+{
+	m_Protocol.SendPacket(*this);
+}
+
+
+
+
+
+void cPacketizer::WriteByteAngle(double a_Angle)
+{
+	WriteChar(static_cast<char>(255 * a_Angle / 360));
+}
+
+
+
+
+
+void cPacketizer::WriteFPInt(double a_Value)
+{
+	Int32 Value = static_cast<Int32>(a_Value * 32);
+	WriteInt(Value);
+}
+
+
+
+
+
+void cPacketizer::WriteUUID(const AString & a_UUID)
+{
+	if (a_UUID.length() != 32)
+	{
+		LOGWARNING("%s: Attempt to send a bad uuid (length isn't 32): %s", __FUNCTION__, a_UUID.c_str());
+		ASSERT(!"Wrong uuid length!");
+		return;
+	}
+
+	for (size_t i = 0; i < 32; i += 2)
+	{
+		auto val = static_cast<UInt8>(HexDigitValue(a_UUID[i]) << 4 | HexDigitValue(a_UUID[i + 1]));
+		VERIFY(m_Out.WriteBEUInt8(val));
+	}
+}
+
+
+
+

--- a/src/Protocol/Packetizer.h
+++ b/src/Protocol/Packetizer.h
@@ -1,0 +1,149 @@
+
+// Packetizer.h
+
+// Declares the cPacketizer class representing a wrapper for sending a single packet over a protocol.
+// The class provides auto-locking, serialization and send-on-instance-destroy semantics
+
+
+
+
+
+#pragma once
+
+#include "Protocol.h"
+#include "../ByteBuffer.h"
+
+
+
+
+
+/** Composes an individual packet in the protocol's m_OutPacketBuffer; sends it just before being destructed. */
+class cPacketizer
+{
+public:
+	/** Starts serializing a new packet into the protocol's m_OutPacketBuffer.
+	Locks the protocol's m_CSPacket to avoid multithreading issues. */
+	cPacketizer(cProtocol & a_Protocol, UInt32 a_PacketType) :
+		m_Protocol(a_Protocol),
+		m_Out(a_Protocol.m_OutPacketBuffer),
+		m_Lock(a_Protocol.m_CSPacket),
+		m_PacketType(a_PacketType)  // Used for logging purposes
+	{
+		m_Out.WriteVarInt(a_PacketType);
+	}
+
+	/** Sends the packet via the contained protocol's SendPacket() function. */
+	~cPacketizer();
+
+	inline void WriteBool(bool a_Value)
+	{
+		VERIFY(m_Out.WriteBool(a_Value));
+	}
+
+	inline void WriteByte(Byte a_Value)
+	{
+		VERIFY(m_Out.WriteBEUInt8(a_Value));
+	}
+
+
+	inline void WriteChar(char a_Value)
+	{
+		VERIFY(m_Out.WriteBEInt8(a_Value));
+	}
+
+
+	inline void WriteShort(short a_Value)
+	{
+		VERIFY(m_Out.WriteBEInt16(a_Value));
+	}
+
+
+	inline void WriteBEUInt16(short a_Value)
+	{
+		VERIFY(m_Out.WriteBEUInt16(a_Value));
+	}
+
+
+	inline void WriteInt(Int32 a_Value)
+	{
+		VERIFY(m_Out.WriteBEInt32(a_Value));
+	}
+
+
+	inline void WriteUInt32(UInt32 a_Value)
+	{
+		VERIFY(m_Out.WriteBEUInt32(a_Value));
+	}
+
+
+	inline void WriteInt64(Int64 a_Value)
+	{
+		VERIFY(m_Out.WriteBEInt64(a_Value));
+	}
+
+
+	inline void WriteFloat(float a_Value)
+	{
+		VERIFY(m_Out.WriteBEFloat(a_Value));
+	}
+
+
+	inline void WriteDouble(double a_Value)
+	{
+		VERIFY(m_Out.WriteBEDouble(a_Value));
+	}
+
+
+	inline void WriteVarInt(UInt32 a_Value)
+	{
+		VERIFY(m_Out.WriteVarInt(a_Value));
+	}
+
+
+	inline void WriteString(const AString & a_Value)
+	{
+		VERIFY(m_Out.WriteVarUTF8String(a_Value));
+	}
+
+
+	inline void WriteBuf(const char * a_Data, size_t a_Size)
+	{
+		VERIFY(m_Out.Write(a_Data, a_Size));
+	}
+
+
+	/** Writes the specified block position as a single encoded 64-bit BigEndian integer. */
+	inline void WritePosition(int a_BlockX, int a_BlockY, int a_BlockZ)
+	{
+		VERIFY(m_Out.WritePosition64(a_BlockX, a_BlockY, a_BlockZ));
+	}
+
+	/** Writes the specified angle using a single byte. */
+	void WriteByteAngle(double a_Angle);
+
+	/** Writes the double value as a 27:5 fixed-point integer. */
+	void WriteFPInt(double a_Value);
+
+	/** Writes the specified UUID as a 128-bit BigEndian integer. */
+	void WriteUUID(const AString & a_UUID);
+
+	UInt32 GetPacketType(void) const { return m_PacketType; }
+
+protected:
+	/** The protocol instance in which the packet is being constructed. */
+	cProtocol & m_Protocol;
+
+	/** The protocol's buffer for the constructed packet data. */
+	cByteBuffer & m_Out;
+
+	/** The RAII lock preventing multithreaded access to the protocol buffer while constructing the packet. */
+	cCSLock m_Lock;
+
+	/** Type of the contained packet.
+	Used for logging purposes, the packet type is encoded into m_Out immediately in constructor. */
+	UInt32 m_PacketType;
+} ;
+
+
+
+

--- a/src/Protocol/Packetizer.h
+++ b/src/Protocol/Packetizer.h
@@ -29,7 +29,7 @@ public:
 		m_Lock(a_Protocol.m_CSPacket),
 		m_PacketType(a_PacketType)  // Used for logging purposes
 	{
-		m_Out.WriteVarInt(a_PacketType);
+		m_Out.WriteVarInt32(a_PacketType);
 	}
 
 	/** Sends the packet via the contained protocol's SendPacket() function. */
@@ -40,19 +40,19 @@ public:
 		VERIFY(m_Out.WriteBool(a_Value));
 	}
 
-	inline void WriteByte(Byte a_Value)
+	inline void WriteBEUInt8(UInt8 a_Value)
 	{
 		VERIFY(m_Out.WriteBEUInt8(a_Value));
 	}
 
 
-	inline void WriteChar(char a_Value)
+	inline void WriteBEInt8(Int8 a_Value)
 	{
 		VERIFY(m_Out.WriteBEInt8(a_Value));
 	}
 
 
-	inline void WriteShort(short a_Value)
+	inline void WriteBEInt16(Int16 a_Value)
 	{
 		VERIFY(m_Out.WriteBEInt16(a_Value));
 	}
@@ -64,39 +64,45 @@ public:
 	}
 
 
-	inline void WriteInt(Int32 a_Value)
+	inline void WriteBEInt32(Int32 a_Value)
 	{
 		VERIFY(m_Out.WriteBEInt32(a_Value));
 	}
 
 
-	inline void WriteUInt32(UInt32 a_Value)
+	inline void WriteBEUInt32(UInt32 a_Value)
 	{
 		VERIFY(m_Out.WriteBEUInt32(a_Value));
 	}
 
 
-	inline void WriteInt64(Int64 a_Value)
+	inline void WriteBEInt64(Int64 a_Value)
 	{
 		VERIFY(m_Out.WriteBEInt64(a_Value));
 	}
 
 
-	inline void WriteFloat(float a_Value)
+	inline void WriteBEUInt64(UInt64 a_Value)
+	{
+		VERIFY(m_Out.WriteBEUInt64(a_Value));
+	}
+
+
+	inline void WriteBEFloat(float a_Value)
 	{
 		VERIFY(m_Out.WriteBEFloat(a_Value));
 	}
 
 
-	inline void WriteDouble(double a_Value)
+	inline void WriteBEDouble(double a_Value)
 	{
 		VERIFY(m_Out.WriteBEDouble(a_Value));
 	}
 
 
-	inline void WriteVarInt(UInt32 a_Value)
+	inline void WriteVarInt32(UInt32 a_Value)
 	{
-		VERIFY(m_Out.WriteVarInt(a_Value));
+		VERIFY(m_Out.WriteVarInt32(a_Value));
 	}
 
 
@@ -113,7 +119,7 @@ public:
 
 
 	/** Writes the specified block position as a single encoded 64-bit BigEndian integer. */
-	inline void WritePosition(int a_BlockX, int a_BlockY, int a_BlockZ)
+	inline void WritePosition64(int a_BlockX, int a_BlockY, int a_BlockZ)
 	{
 		VERIFY(m_Out.WritePosition64(a_BlockX, a_BlockY, a_BlockZ));
 	}

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -59,7 +59,7 @@ public:
 	// Sending stuff to clients (alphabetically sorted):
 	virtual void SendAttachEntity               (const cEntity & a_Entity, const cEntity * a_Vehicle) = 0;
 	virtual void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType) = 0;
-	virtual void SendBlockBreakAnim             (int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) = 0;
+	virtual void SendBlockBreakAnim             (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) = 0;
 	virtual void SendBlockChange                (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) = 0;
 	virtual void SendBlockChanges               (int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes) = 0;
 	virtual void SendChat                       (const AString & a_Message) = 0;

--- a/src/Protocol/Protocol.h
+++ b/src/Protocol/Protocol.h
@@ -14,6 +14,7 @@
 #include "../Endianness.h"
 #include "../Scoreboard.h"
 #include "../Map.h"
+#include "../ByteBuffer.h"
 
 
 
@@ -32,6 +33,7 @@ class cChunkDataSerializer;
 class cFallingBlock;
 class cCompositeChat;
 class cStatManager;
+class cPacketizer;
 
 
 
@@ -47,7 +49,9 @@ class cProtocol
 {
 public:
 	cProtocol(cClientHandle * a_Client) :
-		m_Client(a_Client)
+		m_Client(a_Client),
+		m_OutPacketBuffer(64 KiB),
+		m_OutPacketLenBuffer(20)  // 20 bytes is more than enough for one VarInt
 	{
 	}
 
@@ -136,11 +140,27 @@ public:
 	virtual AString GetAuthServerID(void) = 0;
 
 protected:
-	cClientHandle * m_Client;
-	cCriticalSection m_CSPacket;  // Each SendXYZ() function must acquire this CS in order to send the whole packet at once
+	friend class cPacketizer;
 
-	/// A generic data-sending routine, all outgoing packet data needs to be routed through this so that descendants may override it
+	cClientHandle * m_Client;
+
+	/** Provides synchronization for sending the entire packet at once.
+	Each SendXYZ() function must acquire this CS in order to send the whole packet at once.
+	Automated via cPacketizer class. */
+	cCriticalSection m_CSPacket;
+
+	/** Buffer for composing the outgoing packets, through cPacketizer */
+	cByteBuffer m_OutPacketBuffer;
+	
+	/** Buffer for composing packet length (so that each cPacketizer instance doesn't allocate a new cPacketBuffer) */
+	cByteBuffer m_OutPacketLenBuffer;
+	
+	/** A generic data-sending routine, all outgoing packet data needs to be routed through this so that descendants may override it. */
 	virtual void SendData(const char * a_Data, size_t a_Size) = 0;
+
+	/** Sends a single packet contained within the cPacketizer class.
+	The cPacketizer's destructor calls this to send the contained packet; protocol may transform the data (compression in 1.8 etc). */
+	virtual void SendPacket(cPacketizer & a_Packet) = 0;
 } ;
 
 

--- a/src/Protocol/Protocol17x.cpp
+++ b/src/Protocol/Protocol17x.cpp
@@ -165,8 +165,8 @@ void cProtocol172::SendAttachEntity(const cEntity & a_Entity, const cEntity * a_
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1b);  // Attach Entity packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteUInt32((a_Vehicle != nullptr) ? a_Vehicle->GetUniqueID() : 0);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32((a_Vehicle != nullptr) ? a_Vehicle->GetUniqueID() : 0);
 	Pkt.WriteBool(false);
 }
 
@@ -179,12 +179,12 @@ void cProtocol172::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, cha
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x24);  // Block Action packet
-	Pkt.WriteInt(a_BlockX);
-	Pkt.WriteShort(static_cast<short>(a_BlockY));
-	Pkt.WriteInt(a_BlockZ);
-	Pkt.WriteByte(static_cast<Byte>(a_Byte1));
-	Pkt.WriteByte(static_cast<Byte>(a_Byte2));
-	Pkt.WriteVarInt(a_BlockType);
+	Pkt.WriteBEInt32(a_BlockX);
+	Pkt.WriteBEInt16(static_cast<Int16>(a_BlockY));
+	Pkt.WriteBEInt32(a_BlockZ);
+	Pkt.WriteBEInt8(a_Byte1);
+	Pkt.WriteBEInt8(a_Byte2);
+	Pkt.WriteVarInt32(a_BlockType);
 }
 
 
@@ -196,11 +196,11 @@ void cProtocol172::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_Blo
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x25);  // Block Break Animation packet
-	Pkt.WriteVarInt(a_EntityID);
-	Pkt.WriteInt(a_BlockX);
-	Pkt.WriteInt(a_BlockY);
-	Pkt.WriteInt(a_BlockZ);
-	Pkt.WriteChar(a_Stage);
+	Pkt.WriteVarInt32(a_EntityID);
+	Pkt.WriteBEInt32(a_BlockX);
+	Pkt.WriteBEInt32(a_BlockY);
+	Pkt.WriteBEInt32(a_BlockZ);
+	Pkt.WriteBEInt8(a_Stage);
 }
 
 
@@ -213,11 +213,11 @@ void cProtocol172::SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLO
 	ASSERT((a_BlockY >= 0) && (a_BlockY < 256));
 	
 	cPacketizer Pkt(*this, 0x23);  // Block Change packet
-	Pkt.WriteInt(a_BlockX);
-	Pkt.WriteByte(static_cast<Byte>(a_BlockY));
-	Pkt.WriteInt(a_BlockZ);
-	Pkt.WriteVarInt(a_BlockType);
-	Pkt.WriteByte(a_BlockMeta);
+	Pkt.WriteBEInt32(a_BlockX);
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_BlockY));
+	Pkt.WriteBEInt32(a_BlockZ);
+	Pkt.WriteVarInt32(a_BlockType);
+	Pkt.WriteBEUInt8(a_BlockMeta);
 }
 
 
@@ -229,15 +229,15 @@ void cProtocol172::SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockV
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x22);  // Multi Block Change packet
-	Pkt.WriteInt(a_ChunkX);
-	Pkt.WriteInt(a_ChunkZ);
-	Pkt.WriteShort((short)a_Changes.size());
-	Pkt.WriteInt((int)a_Changes.size() * 4);
+	Pkt.WriteBEInt32(a_ChunkX);
+	Pkt.WriteBEInt32(a_ChunkZ);
+	Pkt.WriteBEUInt16(static_cast<UInt16>(a_Changes.size()));
+	Pkt.WriteBEUInt32(static_cast<UInt32>(a_Changes.size() * 4));
 	for (sSetBlockVector::const_iterator itr = a_Changes.begin(), end = a_Changes.end(); itr != end; ++itr)
 	{
 		int Coords = itr->m_RelY | (itr->m_RelZ << 8) | (itr->m_RelX << 12);
 		int Blocks = static_cast<int>(itr->m_BlockMeta | (itr->m_BlockType << 4));
-		Pkt.WriteInt((Coords << 16) | Blocks);
+		Pkt.WriteBEInt32((Coords << 16) | Blocks);
 	}  // for itr - a_Changes[]
 }
 
@@ -282,8 +282,8 @@ void cProtocol172::SendChunkData(int a_ChunkX, int a_ChunkZ, cChunkDataSerialize
 	const AString & ChunkData = a_Serializer.Serialize(cChunkDataSerializer::RELEASE_1_3_2, a_ChunkX, a_ChunkZ);
 	
 	cPacketizer Pkt(*this, 0x21);  // Chunk Data packet
-	Pkt.WriteInt(a_ChunkX);
-	Pkt.WriteInt(a_ChunkZ);
+	Pkt.WriteBEInt32(a_ChunkX);
+	Pkt.WriteBEInt32(a_ChunkZ);
 	Pkt.WriteBuf(ChunkData.data(), ChunkData.size());
 }
 
@@ -296,8 +296,8 @@ void cProtocol172::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0d);  // Collect Item packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteUInt32(a_Player.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Player.GetUniqueID());
 }
 
 
@@ -309,8 +309,8 @@ void cProtocol172::SendDestroyEntity(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x13);  // Destroy Entities packet
-	Pkt.WriteByte(1);
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt8(1);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 }
 
 
@@ -347,9 +347,9 @@ void cProtocol172::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x36);  // Sign Editor Open packet
-	Pkt.WriteInt(a_BlockX);
-	Pkt.WriteInt(a_BlockY);
-	Pkt.WriteInt(a_BlockZ);
+	Pkt.WriteBEInt32(a_BlockX);
+	Pkt.WriteBEInt32(a_BlockY);
+	Pkt.WriteBEInt32(a_BlockZ);
 }
 
 
@@ -363,10 +363,10 @@ void cProtocol172::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, in
 	ASSERT((a_Amplifier >= 0) && (a_Amplifier < 256));
 	
 	cPacketizer Pkt(*this, 0x1D);  // Entity Effect packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteByte(static_cast<Byte>(a_EffectID));
-	Pkt.WriteByte(static_cast<Byte>(a_Amplifier));
-	Pkt.WriteShort(a_Duration);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_EffectID));
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_Amplifier));
+	Pkt.WriteBEInt16(a_Duration);
 }
 
 
@@ -378,8 +378,8 @@ void cProtocol172::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x04);  // Entity Equipment packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteShort(a_SlotNum);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt16(a_SlotNum);
 	WriteItem(Pkt, a_Item);
 }
 
@@ -392,7 +392,7 @@ void cProtocol172::SendEntityHeadLook(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x19);  // Entity Head Look packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetHeadYaw());
 }
 
@@ -405,7 +405,7 @@ void cProtocol172::SendEntityLook(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x16);  // Entity Look packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 }
@@ -419,9 +419,9 @@ void cProtocol172::SendEntityMetadata(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 	WriteEntityMetadata(Pkt, a_Entity);
-	Pkt.WriteByte(0x7f);  // The termination byte
+	Pkt.WriteBEUInt8(0x7f);  // The termination byte
 }
 
 
@@ -433,7 +433,7 @@ void cProtocol172::SendEntityProperties(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x20);  // Entity Properties packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 	WriteEntityProperties(Pkt, a_Entity);
 }
 
@@ -446,10 +446,10 @@ void cProtocol172::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x15);  // Entity Relative Move packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_RelX);
-	Pkt.WriteChar(a_RelY);
-	Pkt.WriteChar(a_RelZ);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_RelX);
+	Pkt.WriteBEInt8(a_RelY);
+	Pkt.WriteBEInt8(a_RelZ);
 }
 
 
@@ -461,10 +461,10 @@ void cProtocol172::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, 
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x17);  // Entity Look And Relative Move packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_RelX);
-	Pkt.WriteChar(a_RelY);
-	Pkt.WriteChar(a_RelZ);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_RelX);
+	Pkt.WriteBEInt8(a_RelY);
+	Pkt.WriteBEInt8(a_RelZ);
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 }
@@ -478,8 +478,8 @@ void cProtocol172::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1a);  // Entity Status packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_Status);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_Status);
 }
 
 
@@ -491,11 +491,11 @@ void cProtocol172::SendEntityVelocity(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x12);  // Entity Velocity packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 	// 400 = 8000 / 20 ... Conversion from our speed in m/s to 8000 m/tick
-	Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedX() * 400));
-	Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedY() * 400));
-	Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedZ() * 400));
+	Pkt.WriteBEInt16(static_cast<short>(a_Entity.GetSpeedX() * 400));
+	Pkt.WriteBEInt16(static_cast<short>(a_Entity.GetSpeedY() * 400));
+	Pkt.WriteBEInt16(static_cast<short>(a_Entity.GetSpeedZ() * 400));
 }
 
 
@@ -507,20 +507,20 @@ void cProtocol172::SendExplosion(double a_BlockX, double a_BlockY, double a_Bloc
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x27);  // Explosion packet
-	Pkt.WriteFloat((float)a_BlockX);
-	Pkt.WriteFloat((float)a_BlockY);
-	Pkt.WriteFloat((float)a_BlockZ);
-	Pkt.WriteFloat((float)a_Radius);
-	Pkt.WriteInt((int)a_BlocksAffected.size());
+	Pkt.WriteBEFloat(static_cast<float>(a_BlockX));
+	Pkt.WriteBEFloat(static_cast<float>(a_BlockY));
+	Pkt.WriteBEFloat(static_cast<float>(a_BlockZ));
+	Pkt.WriteBEFloat(static_cast<float>(a_Radius));
+	Pkt.WriteBEUInt32(static_cast<UInt32>(a_BlocksAffected.size()));
 	for (cVector3iArray::const_iterator itr = a_BlocksAffected.begin(), end = a_BlocksAffected.end(); itr != end; ++itr)
 	{
-		Pkt.WriteChar((char)itr->x);
-		Pkt.WriteChar((char)itr->y);
-		Pkt.WriteChar((char)itr->z);
+		Pkt.WriteBEInt8(static_cast<Int8>(itr->x));
+		Pkt.WriteBEInt8(static_cast<Int8>(itr->y));
+		Pkt.WriteBEInt8(static_cast<Int8>(itr->z));
 	}  // for itr - a_BlockAffected[]
-	Pkt.WriteFloat((float)a_PlayerMotion.x);
-	Pkt.WriteFloat((float)a_PlayerMotion.y);
-	Pkt.WriteFloat((float)a_PlayerMotion.z);
+	Pkt.WriteBEFloat(static_cast<float>(a_PlayerMotion.x));
+	Pkt.WriteBEFloat(static_cast<float>(a_PlayerMotion.y));
+	Pkt.WriteBEFloat(static_cast<float>(a_PlayerMotion.z));
 }
 
 
@@ -532,8 +532,8 @@ void cProtocol172::SendGameMode(eGameMode a_GameMode)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x2b);  // Change Game State packet
-	Pkt.WriteByte(3);  // Reason: Change game mode
-	Pkt.WriteFloat((float)a_GameMode);
+	Pkt.WriteBEUInt8(3);  // Reason: Change game mode
+	Pkt.WriteBEFloat(static_cast<float>(a_GameMode));  // The protocol really represents the value with a float!
 }
 
 
@@ -546,9 +546,9 @@ void cProtocol172::SendHealth(void)
 	
 	cPacketizer Pkt(*this, 0x06);  // Update Health packet
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteFloat(static_cast<float>(Player->GetHealth()));
-	Pkt.WriteShort(static_cast<short>(Player->GetFoodLevel()));
-	Pkt.WriteFloat(static_cast<float>(Player->GetFoodSaturationLevel()));
+	Pkt.WriteBEFloat(static_cast<float>(Player->GetHealth()));
+	Pkt.WriteBEInt16(static_cast<short>(Player->GetFoodLevel()));
+	Pkt.WriteBEFloat(static_cast<float>(Player->GetFoodSaturationLevel()));
 }
 
 
@@ -560,8 +560,8 @@ void cProtocol172::SendInventorySlot(char a_WindowID, short a_SlotNum, const cIt
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x2f);  // Set Slot packet
-	Pkt.WriteChar(a_WindowID);
-	Pkt.WriteShort(a_SlotNum);
+	Pkt.WriteBEInt8(a_WindowID);
+	Pkt.WriteBEInt16(a_SlotNum);
 	WriteItem(Pkt, a_Item);
 }
 
@@ -579,7 +579,7 @@ void cProtocol172::SendKeepAlive(int a_PingID)
 	}
 	
 	cPacketizer Pkt(*this, 0x00);  // Keep Alive packet
-	Pkt.WriteInt(a_PingID);
+	Pkt.WriteBEInt32(a_PingID);
 }
 
 
@@ -592,11 +592,11 @@ void cProtocol172::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 	{
 		cServer * Server = cRoot::Get()->GetServer();
 		cPacketizer Pkt(*this, 0x01);  // Join Game packet
-		Pkt.WriteUInt32(a_Player.GetUniqueID());
-		Pkt.WriteByte(static_cast<Byte>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
-		Pkt.WriteChar(static_cast<char>(a_World.GetDimension()));
-		Pkt.WriteByte(2);  // TODO: Difficulty (set to Normal)
-		Pkt.WriteByte(static_cast<Byte>(std::min(Server->GetMaxPlayers(), 60)));
+		Pkt.WriteBEUInt32(a_Player.GetUniqueID());
+		Pkt.WriteBEUInt8(static_cast<Byte>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
+		Pkt.WriteBEInt8(static_cast<char>(a_World.GetDimension()));
+		Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
+		Pkt.WriteBEUInt8(static_cast<Byte>(std::min(Server->GetMaxPlayers(), 60)));
 		Pkt.WriteString("default");  // Level type - wtf?
 	}
 	m_LastSentDimension = a_World.GetDimension();
@@ -604,9 +604,9 @@ void cProtocol172::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 	// Send the spawn position:
 	{
 		cPacketizer Pkt(*this, 0x05);  // Spawn Position packet
-		Pkt.WriteInt(static_cast<int>(a_World.GetSpawnX()));
-		Pkt.WriteInt(static_cast<int>(a_World.GetSpawnY()));
-		Pkt.WriteInt(static_cast<int>(a_World.GetSpawnZ()));
+		Pkt.WriteBEInt32(static_cast<int>(a_World.GetSpawnX()));
+		Pkt.WriteBEInt32(static_cast<int>(a_World.GetSpawnY()));
+		Pkt.WriteBEInt32(static_cast<int>(a_World.GetSpawnZ()));
 	}
 	
 	// Send player abilities:
@@ -638,12 +638,12 @@ void cProtocol172::SendPaintingSpawn(const cPainting & a_Painting)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x10);  // Spawn Painting packet
-	Pkt.WriteVarInt(a_Painting.GetUniqueID());
+	Pkt.WriteVarInt32(a_Painting.GetUniqueID());
 	Pkt.WriteString(a_Painting.GetName().c_str());
-	Pkt.WriteInt(static_cast<int>(a_Painting.GetPosX()));
-	Pkt.WriteInt(static_cast<int>(a_Painting.GetPosY()));
-	Pkt.WriteInt(static_cast<int>(a_Painting.GetPosZ()));
-	Pkt.WriteInt(a_Painting.GetProtocolFacing());
+	Pkt.WriteBEInt32(static_cast<int>(a_Painting.GetPosX()));
+	Pkt.WriteBEInt32(static_cast<int>(a_Painting.GetPosY()));
+	Pkt.WriteBEInt32(static_cast<int>(a_Painting.GetPosZ()));
+	Pkt.WriteBEInt32(a_Painting.GetProtocolFacing());
 }
 
 
@@ -658,12 +658,12 @@ void cProtocol172::SendMapColumn(int a_MapID, int a_X, int a_Y, const Byte * a_C
 	ASSERT((a_Y >= 0) && (a_Y < 256));
 	
 	cPacketizer Pkt(*this, 0x34);
-	Pkt.WriteVarInt(static_cast<UInt32>(a_MapID));
-	Pkt.WriteShort (static_cast<short>(3 + a_Length));
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_MapID));
+	Pkt.WriteBEUInt16(static_cast<UInt16>(3 + a_Length));
 
-	Pkt.WriteByte(0);
-	Pkt.WriteByte(static_cast<Byte>(a_X));
-	Pkt.WriteByte(static_cast<Byte>(a_Y));
+	Pkt.WriteBEUInt8(0);
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_X));
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_Y));
 	
 	Pkt.WriteBuf(reinterpret_cast<const char *>(a_Colors), a_Length);
 }
@@ -678,18 +678,18 @@ void cProtocol172::SendMapDecorators(int a_MapID, const cMapDecoratorList & a_De
 	ASSERT(1 + 3 * a_Decorators.size() < USHRT_MAX);
 	
 	cPacketizer Pkt(*this, 0x34);
-	Pkt.WriteVarInt(static_cast<UInt32>(a_MapID));
-	Pkt.WriteShort (static_cast<short>(1 + (3 * a_Decorators.size())));
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_MapID));
+	Pkt.WriteBEUInt16(static_cast<UInt16>(1 + (3 * a_Decorators.size())));
 
-	Pkt.WriteByte(1);
+	Pkt.WriteBEUInt8(1);
 	
 	for (cMapDecoratorList::const_iterator it = a_Decorators.begin(); it != a_Decorators.end(); ++it)
 	{
 		ASSERT(it->GetPixelX() < 256);
 		ASSERT(it->GetPixelZ() < 256);
-		Pkt.WriteByte(static_cast<Byte>((it->GetType() << 4) | static_cast<Byte>(it->GetRot() & 0xf)));
-		Pkt.WriteByte(static_cast<Byte>(it->GetPixelX()));
-		Pkt.WriteByte(static_cast<Byte>(it->GetPixelZ()));
+		Pkt.WriteBEUInt8(static_cast<Byte>((it->GetType() << 4) | static_cast<Byte>(it->GetRot() & 0xf)));
+		Pkt.WriteBEUInt8(static_cast<Byte>(it->GetPixelX()));
+		Pkt.WriteBEUInt8(static_cast<Byte>(it->GetPixelZ()));
 	}
 }
 
@@ -703,11 +703,11 @@ void cProtocol172::SendMapInfo(int a_MapID, unsigned int a_Scale)
 	ASSERT(a_Scale < 256);
 	
 	cPacketizer Pkt(*this, 0x34);
-	Pkt.WriteVarInt(static_cast<UInt32>(a_MapID));
-	Pkt.WriteShort (2);
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_MapID));
+	Pkt.WriteBEUInt16(2);
 
-	Pkt.WriteByte(2);
-	Pkt.WriteByte(static_cast<Byte>(a_Scale));
+	Pkt.WriteBEUInt8(2);
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_Scale));
 }
 
 
@@ -720,21 +720,21 @@ void cProtocol172::SendPickupSpawn(const cPickup & a_Pickup)
 	
 	{
 		cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
-		Pkt.WriteVarInt(a_Pickup.GetUniqueID());
-		Pkt.WriteByte(2);  // Type = Pickup
+		Pkt.WriteVarInt32(a_Pickup.GetUniqueID());
+		Pkt.WriteBEUInt8(2);  // Type = Pickup
 		Pkt.WriteFPInt(a_Pickup.GetPosX());
 		Pkt.WriteFPInt(a_Pickup.GetPosY());
 		Pkt.WriteFPInt(a_Pickup.GetPosZ());
 		Pkt.WriteByteAngle(a_Pickup.GetYaw());
 		Pkt.WriteByteAngle(a_Pickup.GetPitch());
-		Pkt.WriteInt(0);  // No object data
+		Pkt.WriteBEInt32(0);  // No object data
 	}
 	{
 		cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
-		Pkt.WriteUInt32(a_Pickup.GetUniqueID());
-		Pkt.WriteByte((0x05 << 5) | 10);  // Slot type + index 10
+		Pkt.WriteBEUInt32(a_Pickup.GetUniqueID());
+		Pkt.WriteBEUInt8((0x05 << 5) | 10);  // Slot type + index 10
 		WriteItem(Pkt, a_Pickup.GetItem());
-		Pkt.WriteByte(0x7f);  // End of metadata
+		Pkt.WriteBEUInt8(0x7f);  // End of metadata
 	}
 }
 
@@ -762,9 +762,9 @@ void cProtocol172::SendPlayerAbilities(void)
 	{
 		Flags |= 0x04;
 	}
-	Pkt.WriteByte(Flags);
-	Pkt.WriteFloat((float)(0.05 * Player->GetFlyingMaxSpeed()));
-	Pkt.WriteFloat((float)(0.1 * Player->GetNormalMaxSpeed()));
+	Pkt.WriteBEUInt8(Flags);
+	Pkt.WriteBEFloat(static_cast<float>(0.05 * Player->GetFlyingMaxSpeed()));
+	Pkt.WriteBEFloat(static_cast<float>(0.1 * Player->GetNormalMaxSpeed()));
 }
 
 
@@ -776,8 +776,8 @@ void cProtocol172::SendEntityAnimation(const cEntity & a_Entity, char a_Animatio
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0b);  // Animation packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_Animation);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_Animation);
 }
 
 
@@ -790,14 +790,14 @@ void cProtocol172::SendParticleEffect(const AString & a_ParticleName, float a_Sr
 	
 	cPacketizer Pkt(*this, 0x2A);
 	Pkt.WriteString(a_ParticleName);
-	Pkt.WriteFloat(a_SrcX);
-	Pkt.WriteFloat(a_SrcY);
-	Pkt.WriteFloat(a_SrcZ);
-	Pkt.WriteFloat(a_OffsetX);
-	Pkt.WriteFloat(a_OffsetY);
-	Pkt.WriteFloat(a_OffsetZ);
-	Pkt.WriteFloat(a_ParticleData);
-	Pkt.WriteInt(a_ParticleAmount);
+	Pkt.WriteBEFloat(a_SrcX);
+	Pkt.WriteBEFloat(a_SrcY);
+	Pkt.WriteBEFloat(a_SrcZ);
+	Pkt.WriteBEFloat(a_OffsetX);
+	Pkt.WriteBEFloat(a_OffsetY);
+	Pkt.WriteBEFloat(a_OffsetZ);
+	Pkt.WriteBEFloat(a_ParticleData);
+	Pkt.WriteBEInt32(a_ParticleAmount);
 }
 
 
@@ -811,7 +811,7 @@ void cProtocol172::SendPlayerListAddPlayer(const cPlayer & a_Player)
 	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
 	Pkt.WriteString(a_Player.GetPlayerListName());
 	Pkt.WriteBool(true);
-	Pkt.WriteShort(a_Player.GetClientHandle()->GetPing());
+	Pkt.WriteBEInt16(a_Player.GetClientHandle()->GetPing());
 }
 
 
@@ -825,7 +825,7 @@ void cProtocol172::SendPlayerListRemovePlayer(const cPlayer & a_Player)
 	cPacketizer Pkt(*this, 0x38);
 	Pkt.WriteString(a_Player.GetPlayerListName());
 	Pkt.WriteBool(false);
-	Pkt.WriteShort(0);
+	Pkt.WriteBEInt16(0);
 }
 
 
@@ -869,22 +869,22 @@ void cProtocol172::SendPlayerMaxSpeed(void)
 	
 	cPacketizer Pkt(*this, 0x20);  // Entity Properties
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteUInt32(Player->GetUniqueID());
-	Pkt.WriteInt(1);  // Count
+	Pkt.WriteBEUInt32(Player->GetUniqueID());
+	Pkt.WriteBEInt32(1);  // Count
 	Pkt.WriteString("generic.movementSpeed");
 	// The default game speed is 0.1, multiply that value by the relative speed:
-	Pkt.WriteDouble(0.1 * Player->GetNormalMaxSpeed());
+	Pkt.WriteBEDouble(0.1 * Player->GetNormalMaxSpeed());
 	if (Player->IsSprinting())
 	{
-		Pkt.WriteShort(1);  // Modifier count
-		Pkt.WriteInt64(0x662a6b8dda3e4c1c);
-		Pkt.WriteInt64(static_cast<Int64>(0x881396ea6097278d));  // UUID of the modifier
-		Pkt.WriteDouble(Player->GetSprintingMaxSpeed() - Player->GetNormalMaxSpeed());
-		Pkt.WriteByte(2);
+		Pkt.WriteBEInt16(1);  // Modifier count
+		Pkt.WriteBEUInt64(0x662a6b8dda3e4c1c);
+		Pkt.WriteBEUInt64(0x881396ea6097278d);  // UUID of the modifier
+		Pkt.WriteBEDouble(Player->GetSprintingMaxSpeed() - Player->GetNormalMaxSpeed());
+		Pkt.WriteBEUInt8(2);
 	}
 	else
 	{
-		Pkt.WriteShort(0);  // Modifier count
+		Pkt.WriteBEInt16(0);  // Modifier count
 	}
 }
 
@@ -898,15 +898,15 @@ void cProtocol172::SendPlayerMoveLook(void)
 	
 	cPacketizer Pkt(*this, 0x08);  // Player Position And Look packet
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteDouble(Player->GetPosX());
+	Pkt.WriteBEDouble(Player->GetPosX());
 	
 	// Protocol docs say this is PosY, but #323 says this is eye-pos
 	// Moreover, the "+ 0.001" is there because otherwise the player falls through the block they were standing on.
-	Pkt.WriteDouble(Player->GetStance() + 0.001);
+	Pkt.WriteBEDouble(Player->GetStance() + 0.001);
 	
-	Pkt.WriteDouble(Player->GetPosZ());
-	Pkt.WriteFloat((float)Player->GetYaw());
-	Pkt.WriteFloat((float)Player->GetPitch());
+	Pkt.WriteBEDouble(Player->GetPosZ());
+	Pkt.WriteBEFloat(static_cast<float>(Player->GetYaw()));
+	Pkt.WriteBEFloat(static_cast<float>(Player->GetPitch()));
 	Pkt.WriteBool(Player->IsOnGround());
 }
 
@@ -930,7 +930,7 @@ void cProtocol172::SendPlayerSpawn(const cPlayer & a_Player)
 	
 	// Called to spawn another player for the client
 	cPacketizer Pkt(*this, 0x0c);  // Spawn Player packet
-	Pkt.WriteVarInt(a_Player.GetUniqueID());
+	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 	Pkt.WriteString(cMojangAPI::MakeUUIDDashed(a_Player.GetClientHandle()->GetUUID()));
 	if (a_Player.HasCustomName())
 	{
@@ -946,10 +946,10 @@ void cProtocol172::SendPlayerSpawn(const cPlayer & a_Player)
 	Pkt.WriteByteAngle(a_Player.GetYaw());
 	Pkt.WriteByteAngle(a_Player.GetPitch());
 	short ItemType = a_Player.GetEquippedItem().IsEmpty() ? 0 : a_Player.GetEquippedItem().m_ItemType;
-	Pkt.WriteShort(ItemType);
-	Pkt.WriteByte((3 << 5) | 6);  // Metadata: float + index 6
-	Pkt.WriteFloat((float)a_Player.GetHealth());
-	Pkt.WriteByte(0x7f);  // Metadata: end
+	Pkt.WriteBEInt16(ItemType);
+	Pkt.WriteBEUInt8((3 << 5) | 6);  // Metadata: float + index 6
+	Pkt.WriteBEFloat(static_cast<float>(a_Player.GetHealth()));
+	Pkt.WriteBEUInt8(0x7f);  // Metadata: end
 }
 
 
@@ -959,10 +959,11 @@ void cProtocol172::SendPlayerSpawn(const cPlayer & a_Player)
 void cProtocol172::SendPluginMessage(const AString & a_Channel, const AString & a_Message)
 {
 	ASSERT(m_State == 3);  // In game mode?
+	ASSERT(a_Message.size() <= std::numeric_limits<UInt16>::max());
 	
 	cPacketizer Pkt(*this, 0x3f);
 	Pkt.WriteString(a_Channel);
-	Pkt.WriteShort((short)a_Message.size());
+	Pkt.WriteBEUInt16(static_cast<UInt16>(a_Message.size()));
 	Pkt.WriteBuf(a_Message.data(), a_Message.size());
 }
 
@@ -976,8 +977,8 @@ void cProtocol172::SendRemoveEntityEffect(const cEntity & a_Entity, int a_Effect
 	ASSERT((a_EffectID >= 0) && (a_EffectID < 256));
 	
 	cPacketizer Pkt(*this, 0x1e);
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteByte(static_cast<Byte>(a_EffectID));
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_EffectID));
 }
 
 
@@ -994,9 +995,9 @@ void cProtocol172::SendRespawn(eDimension a_Dimension, bool a_ShouldIgnoreDimens
 
 	cPacketizer Pkt(*this, 0x07);  // Respawn packet
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteInt((int)a_Dimension);
-	Pkt.WriteByte(2);  // TODO: Difficulty (set to Normal)
-	Pkt.WriteByte((Byte)Player->GetEffectiveGameMode());
+	Pkt.WriteBEInt32((int)a_Dimension);
+	Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
+	Pkt.WriteBEUInt8((Byte)Player->GetEffectiveGameMode());
 	Pkt.WriteString("default");
 	m_LastSentDimension = a_Dimension;
 }
@@ -1011,9 +1012,9 @@ void cProtocol172::SendExperience (void)
 	
 	cPacketizer Pkt(*this, 0x1f);  // Experience Packet
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteFloat(Player->GetXpPercentage());
-	Pkt.WriteShort(static_cast<UInt16>(std::max<int>(Player->GetXpLevel(), std::numeric_limits<UInt16>::max())));
-	Pkt.WriteShort(static_cast<UInt16>(std::max<int>(Player->GetCurrentXp(), std::numeric_limits<UInt16>::max())));
+	Pkt.WriteBEFloat(Player->GetXpPercentage());
+	Pkt.WriteBEInt16(static_cast<UInt16>(std::max<int>(Player->GetXpLevel(), std::numeric_limits<UInt16>::max())));
+	Pkt.WriteBEInt16(static_cast<UInt16>(std::max<int>(Player->GetCurrentXp(), std::numeric_limits<UInt16>::max())));
 }
 
 
@@ -1026,11 +1027,11 @@ void cProtocol172::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 	ASSERT((a_ExpOrb.GetReward() >= 0) && (a_ExpOrb.GetReward() < SHRT_MAX));
 	
 	cPacketizer Pkt(*this, 0x11);
-	Pkt.WriteVarInt(a_ExpOrb.GetUniqueID());
+	Pkt.WriteVarInt32(a_ExpOrb.GetUniqueID());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosX());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosY());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosZ());
-	Pkt.WriteShort(static_cast<short>(a_ExpOrb.GetReward()));
+	Pkt.WriteBEInt16(static_cast<short>(a_ExpOrb.GetReward()));
 }
 
 
@@ -1044,7 +1045,7 @@ void cProtocol172::SendScoreboardObjective(const AString & a_Name, const AString
 	cPacketizer Pkt(*this, 0x3b);
 	Pkt.WriteString(a_Name);
 	Pkt.WriteString(a_DisplayName);
-	Pkt.WriteByte(a_Mode);
+	Pkt.WriteBEUInt8(a_Mode);
 }
 
 
@@ -1057,12 +1058,12 @@ void cProtocol172::SendScoreUpdate(const AString & a_Objective, const AString & 
 	
 	cPacketizer Pkt(*this, 0x3c);
 	Pkt.WriteString(a_Player);
-	Pkt.WriteByte(a_Mode);
+	Pkt.WriteBEUInt8(a_Mode);
 
 	if (a_Mode != 1)
 	{
 		Pkt.WriteString(a_Objective);
-		Pkt.WriteInt((int) a_Score);
+		Pkt.WriteBEInt32((int) a_Score);
 	}
 }
 
@@ -1075,7 +1076,7 @@ void cProtocol172::SendDisplayObjective(const AString & a_Objective, cScoreboard
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x3d);
-	Pkt.WriteByte(static_cast<Byte>(a_Display));
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_Display));
 	Pkt.WriteString(a_Objective);
 }
 
@@ -1089,11 +1090,11 @@ void cProtocol172::SendSoundEffect(const AString & a_SoundName, double a_X, doub
 
 	cPacketizer Pkt(*this, 0x29);  // Sound Effect packet
 	Pkt.WriteString(a_SoundName);
-	Pkt.WriteInt(static_cast<int>(a_X * 8.0));
-	Pkt.WriteInt(static_cast<int>(a_Y * 8.0));
-	Pkt.WriteInt(static_cast<int>(a_Z * 8.0));
-	Pkt.WriteFloat(a_Volume);
-	Pkt.WriteByte(static_cast<Byte>(a_Pitch * 63));
+	Pkt.WriteBEInt32(static_cast<int>(a_X * 8.0));
+	Pkt.WriteBEInt32(static_cast<int>(a_Y * 8.0));
+	Pkt.WriteBEInt32(static_cast<int>(a_Z * 8.0));
+	Pkt.WriteBEFloat(a_Volume);
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_Pitch * 63));
 }
 
 
@@ -1106,11 +1107,11 @@ void cProtocol172::SendSoundParticleEffect(int a_EffectID, int a_SrcX, int a_Src
 	ASSERT((a_SrcY >= 0) && (a_SrcY < 256));
 	
 	cPacketizer Pkt(*this, 0x28);  // Effect packet
-	Pkt.WriteInt(a_EffectID);
-	Pkt.WriteInt(a_SrcX);
-	Pkt.WriteByte(static_cast<Byte>(a_SrcY));
-	Pkt.WriteInt(a_SrcZ);
-	Pkt.WriteInt(a_Data);
+	Pkt.WriteBEInt32(a_EffectID);
+	Pkt.WriteBEInt32(a_SrcX);
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_SrcY));
+	Pkt.WriteBEInt32(a_SrcZ);
+	Pkt.WriteBEInt32(a_Data);
 	Pkt.WriteBool(false);
 }
 
@@ -1123,17 +1124,17 @@ void cProtocol172::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
-	Pkt.WriteVarInt(a_FallingBlock.GetUniqueID());
-	Pkt.WriteByte(70);  // Falling block
+	Pkt.WriteVarInt32(a_FallingBlock.GetUniqueID());
+	Pkt.WriteBEUInt8(70);  // Falling block
 	Pkt.WriteFPInt(a_FallingBlock.GetPosX());
 	Pkt.WriteFPInt(a_FallingBlock.GetPosY());
 	Pkt.WriteFPInt(a_FallingBlock.GetPosZ());
 	Pkt.WriteByteAngle(a_FallingBlock.GetYaw());
 	Pkt.WriteByteAngle(a_FallingBlock.GetPitch());
-	Pkt.WriteInt((static_cast<int>(a_FallingBlock.GetBlockType()) | ((static_cast<int>(a_FallingBlock.GetBlockMeta()) << 16))));
-	Pkt.WriteShort(static_cast<short>(a_FallingBlock.GetSpeedX() * 400));
-	Pkt.WriteShort(static_cast<short>(a_FallingBlock.GetSpeedY() * 400));
-	Pkt.WriteShort(static_cast<short>(a_FallingBlock.GetSpeedZ() * 400));
+	Pkt.WriteBEInt32((static_cast<int>(a_FallingBlock.GetBlockType()) | ((static_cast<int>(a_FallingBlock.GetBlockMeta()) << 16))));
+	Pkt.WriteBEInt16(static_cast<short>(a_FallingBlock.GetSpeedX() * 400));
+	Pkt.WriteBEInt16(static_cast<short>(a_FallingBlock.GetSpeedY() * 400));
+	Pkt.WriteBEInt16(static_cast<short>(a_FallingBlock.GetSpeedZ() * 400));
 }
 
 
@@ -1145,19 +1146,19 @@ void cProtocol172::SendSpawnMob(const cMonster & a_Mob)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0f);  // Spawn Mob packet
-	Pkt.WriteVarInt(a_Mob.GetUniqueID());
-	Pkt.WriteByte((Byte)a_Mob.GetMobType());
+	Pkt.WriteVarInt32(a_Mob.GetUniqueID());
+	Pkt.WriteBEUInt8((Byte)a_Mob.GetMobType());
 	Pkt.WriteFPInt(a_Mob.GetPosX());
 	Pkt.WriteFPInt(a_Mob.GetPosY());
 	Pkt.WriteFPInt(a_Mob.GetPosZ());
 	Pkt.WriteByteAngle(a_Mob.GetPitch());
 	Pkt.WriteByteAngle(a_Mob.GetHeadYaw());
 	Pkt.WriteByteAngle(a_Mob.GetYaw());
-	Pkt.WriteShort(static_cast<short>(a_Mob.GetSpeedX() * 400));
-	Pkt.WriteShort(static_cast<short>(a_Mob.GetSpeedY() * 400));
-	Pkt.WriteShort(static_cast<short>(a_Mob.GetSpeedZ() * 400));
+	Pkt.WriteBEInt16(static_cast<short>(a_Mob.GetSpeedX() * 400));
+	Pkt.WriteBEInt16(static_cast<short>(a_Mob.GetSpeedY() * 400));
+	Pkt.WriteBEInt16(static_cast<short>(a_Mob.GetSpeedZ() * 400));
 	WriteEntityMetadata(Pkt, a_Mob);
-	Pkt.WriteByte(0x7f);  // Metadata terminator
+	Pkt.WriteBEUInt8(0x7f);  // Metadata terminator
 }
 
 
@@ -1169,19 +1170,19 @@ void cProtocol172::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, 
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_ObjectType);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_ObjectType);
 	Pkt.WriteFPInt(a_Entity.GetPosX());
 	Pkt.WriteFPInt(a_Entity.GetPosY());
 	Pkt.WriteFPInt(a_Entity.GetPosZ());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
-	Pkt.WriteInt(a_ObjectData);
+	Pkt.WriteBEInt32(a_ObjectData);
 	if (a_ObjectData != 0)
 	{
-		Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedX() * 400));
-		Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedY() * 400));
-		Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedZ() * 400));
+		Pkt.WriteBEInt16(static_cast<short>(a_Entity.GetSpeedX() * 400));
+		Pkt.WriteBEInt16(static_cast<short>(a_Entity.GetSpeedY() * 400));
+		Pkt.WriteBEInt16(static_cast<short>(a_Entity.GetSpeedZ() * 400));
 	}
 }
 
@@ -1194,19 +1195,19 @@ void cProtocol172::SendSpawnVehicle(const cEntity & a_Vehicle, char a_VehicleTyp
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
-	Pkt.WriteVarInt(a_Vehicle.GetUniqueID());
-	Pkt.WriteChar(a_VehicleType);
+	Pkt.WriteVarInt32(a_Vehicle.GetUniqueID());
+	Pkt.WriteBEInt8(a_VehicleType);
 	Pkt.WriteFPInt(a_Vehicle.GetPosX());
 	Pkt.WriteFPInt(a_Vehicle.GetPosY());
 	Pkt.WriteFPInt(a_Vehicle.GetPosZ());
 	Pkt.WriteByteAngle(a_Vehicle.GetPitch());
 	Pkt.WriteByteAngle(a_Vehicle.GetYaw());
-	Pkt.WriteInt(a_VehicleSubType);
+	Pkt.WriteBEInt32(a_VehicleSubType);
 	if (a_VehicleSubType != 0)
 	{
-		Pkt.WriteShort(static_cast<Int16>(a_Vehicle.GetSpeedX() * 400));
-		Pkt.WriteShort(static_cast<Int16>(a_Vehicle.GetSpeedY() * 400));
-		Pkt.WriteShort(static_cast<Int16>(a_Vehicle.GetSpeedZ() * 400));
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedX() * 400));
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedY() * 400));
+		Pkt.WriteBEInt16(static_cast<Int16>(a_Vehicle.GetSpeedZ() * 400));
 	}
 }
 
@@ -1219,7 +1220,7 @@ void cProtocol172::SendStatistics(const cStatManager & a_Manager)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x37);
-	Pkt.WriteVarInt(statCount);  // TODO 2014-05-11 xdot: Optimization: Send "dirty" statistics only
+	Pkt.WriteVarInt32(statCount);  // TODO 2014-05-11 xdot: Optimization: Send "dirty" statistics only
 
 	for (size_t i = 0; i < (size_t)statCount; ++i)
 	{
@@ -1227,7 +1228,7 @@ void cProtocol172::SendStatistics(const cStatManager & a_Manager)
 		const AString & StatName = cStatInfo::GetName((eStatistic) i);
 
 		Pkt.WriteString(StatName);
-		Pkt.WriteVarInt(static_cast<UInt32>(Value));
+		Pkt.WriteVarInt32(static_cast<UInt32>(Value));
 	}
 }
 
@@ -1240,7 +1241,7 @@ void cProtocol172::SendTabCompletionResults(const AStringVector & a_Results)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x3a);  // Tab-Complete packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_Results.size()));
+	Pkt.WriteVarInt32(static_cast<UInt32>(a_Results.size()));
 
 	for (AStringVector::const_iterator itr = a_Results.begin(), end = a_Results.end(); itr != end; ++itr)
 	{
@@ -1257,7 +1258,7 @@ void cProtocol172::SendTeleportEntity(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x18);
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteFPInt(a_Entity.GetPosX());
 	Pkt.WriteFPInt(a_Entity.GetPosY());
 	Pkt.WriteFPInt(a_Entity.GetPosZ());
@@ -1274,8 +1275,8 @@ void cProtocol172::SendThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x2c);  // Spawn Global Entity packet
-	Pkt.WriteVarInt(0);  // EntityID = 0, always
-	Pkt.WriteByte(1);  // Type = Thunderbolt
+	Pkt.WriteVarInt32(0);  // EntityID = 0, always
+	Pkt.WriteBEUInt8(1);  // Type = Thunderbolt
 	Pkt.WriteFPInt(a_BlockX);
 	Pkt.WriteFPInt(a_BlockY);
 	Pkt.WriteFPInt(a_BlockZ);
@@ -1295,8 +1296,8 @@ void cProtocol172::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_Do
 	}
 	
 	cPacketizer Pkt(*this, 0x03);
-	Pkt.WriteInt64(a_WorldAge);
-	Pkt.WriteInt64(a_TimeOfDay);
+	Pkt.WriteBEInt64(a_WorldAge);
+	Pkt.WriteBEInt64(a_TimeOfDay);
 }
 
 
@@ -1308,12 +1309,12 @@ void cProtocol172::SendUnloadChunk(int a_ChunkX, int a_ChunkZ)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x21);  // Chunk Data packet
-	Pkt.WriteInt(a_ChunkX);
-	Pkt.WriteInt(a_ChunkZ);
+	Pkt.WriteBEInt32(a_ChunkX);
+	Pkt.WriteBEInt32(a_ChunkZ);
 	Pkt.WriteBool(true);
-	Pkt.WriteShort(0);  // Primary bitmap
-	Pkt.WriteShort(0);  // Add bitmap
-	Pkt.WriteInt(0);  // Compressed data size
+	Pkt.WriteBEInt16(0);  // Primary bitmap
+	Pkt.WriteBEInt16(0);  // Add bitmap
+	Pkt.WriteBEInt32(0);  // Compressed data size
 }
 
 
@@ -1324,9 +1325,9 @@ void cProtocol172::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x35);  // Update tile entity packet
-	Pkt.WriteInt(a_BlockEntity.GetPosX());
-	Pkt.WriteShort(static_cast<short>(a_BlockEntity.GetPosY()));
-	Pkt.WriteInt(a_BlockEntity.GetPosZ());
+	Pkt.WriteBEInt32(a_BlockEntity.GetPosX());
+	Pkt.WriteBEInt16(static_cast<short>(a_BlockEntity.GetPosY()));
+	Pkt.WriteBEInt32(a_BlockEntity.GetPosZ());
 
 	Byte Action = 0;
 	switch (a_BlockEntity.GetBlockType())
@@ -1338,7 +1339,7 @@ void cProtocol172::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 		case E_BLOCK_FLOWER_POT:    Action = 5; break;  // Update flower pot
 		default: ASSERT(!"Unhandled or unimplemented BlockEntity update request!"); break;
 	}
-	Pkt.WriteByte(Action);
+	Pkt.WriteBEUInt8(Action);
 
 	WriteBlockEntity(Pkt, a_BlockEntity);
 }
@@ -1353,9 +1354,9 @@ void cProtocol172::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, cons
 	ASSERT((a_BlockY >= 0) && (a_BlockY < cChunkDef::Height));
 	
 	cPacketizer Pkt(*this, 0x33);
-	Pkt.WriteInt(a_BlockX);
-	Pkt.WriteShort((short)a_BlockY);
-	Pkt.WriteInt(a_BlockZ);
+	Pkt.WriteBEInt32(a_BlockX);
+	Pkt.WriteBEInt16(static_cast<Int16>(a_BlockY));
+	Pkt.WriteBEInt32(a_BlockZ);
 	// Need to send only up to 15 chars, otherwise the client crashes (#598)
 	Pkt.WriteString(a_Line1.substr(0, 15));
 	Pkt.WriteString(a_Line2.substr(0, 15));
@@ -1373,10 +1374,10 @@ void cProtocol172::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_Bloc
 	ASSERT((a_BlockY >= 0) && (a_BlockY < cChunkDef::Height));
 	
 	cPacketizer Pkt(*this, 0x0a);
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteInt(a_BlockX);
-	Pkt.WriteByte(static_cast<Byte>(a_BlockY));
-	Pkt.WriteInt(a_BlockZ);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt32(a_BlockX);
+	Pkt.WriteBEUInt8(static_cast<Byte>(a_BlockY));
+	Pkt.WriteBEInt32(a_BlockZ);
 }
 
 
@@ -1389,8 +1390,8 @@ void cProtocol172::SendWeather(eWeather a_Weather)
 	
 	{
 		cPacketizer Pkt(*this, 0x2b);  // Change Game State packet
-		Pkt.WriteByte((a_Weather == wSunny) ? 1 : 2);  // End rain / begin rain
-		Pkt.WriteFloat(0);  // Unused for weather
+		Pkt.WriteBEUInt8((a_Weather == wSunny) ? 1 : 2);  // End rain / begin rain
+		Pkt.WriteBEFloat(0);  // Unused for weather
 	}
 
 	// TODO: Fade effect, somehow
@@ -1405,8 +1406,8 @@ void cProtocol172::SendWholeInventory(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x30);  // Window Items packet
-	Pkt.WriteChar(a_Window.GetWindowID());
-	Pkt.WriteShort(static_cast<short>(a_Window.GetNumSlots()));
+	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEInt16(static_cast<short>(a_Window.GetNumSlots()));
 	cItems Slots;
 	a_Window.GetSlots(*(m_Client->GetPlayer()), Slots);
 	for (cItems::const_iterator itr = Slots.begin(), end = Slots.end(); itr != end; ++itr)
@@ -1424,7 +1425,7 @@ void cProtocol172::SendWindowClose(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x2e);
-	Pkt.WriteChar(a_Window.GetWindowID());
+	Pkt.WriteBEInt8(a_Window.GetWindowID());
 }
 
 
@@ -1442,14 +1443,14 @@ void cProtocol172::SendWindowOpen(const cWindow & a_Window)
 	}
 	
 	cPacketizer Pkt(*this, 0x2d);
-	Pkt.WriteChar(a_Window.GetWindowID());
-	Pkt.WriteChar(static_cast<char>(a_Window.GetWindowType()));
+	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEInt8(static_cast<char>(a_Window.GetWindowType()));
 	Pkt.WriteString(a_Window.GetWindowTitle());
-	Pkt.WriteChar(static_cast<char>(a_Window.GetNumNonInventorySlots()));
+	Pkt.WriteBEInt8(static_cast<char>(a_Window.GetNumNonInventorySlots()));
 	Pkt.WriteBool(true);
 	if (a_Window.GetWindowType() == cWindow::wtAnimalChest)
 	{
-		Pkt.WriteInt(0);  // TODO: The animal's EntityID
+		Pkt.WriteBEInt32(0);  // TODO: The animal's EntityID
 	}
 }
 
@@ -1462,9 +1463,9 @@ void cProtocol172::SendWindowProperty(const cWindow & a_Window, short a_Property
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x31);  // Window Property packet
-	Pkt.WriteChar(a_Window.GetWindowID());
-	Pkt.WriteShort(a_Property);
-	Pkt.WriteShort(a_Value);
+	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEInt16(a_Property);
+	Pkt.WriteBEInt16(a_Value);
 }
 
 
@@ -1709,7 +1710,7 @@ void cProtocol172::HandlePacketStatusPing(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEInt64, Int64, Timestamp);
 
 	cPacketizer Pkt(*this, 0x01);  // Ping packet
-	Pkt.WriteInt64(Timestamp);
+	Pkt.WriteBEInt64(Timestamp);
 }
 
 
@@ -1858,10 +1859,10 @@ void cProtocol172::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 		cPacketizer Pkt(*this, 0x01);
 		Pkt.WriteString(Server->GetServerID());
 		const AString & PubKeyDer = Server->GetPublicKeyDER();
-		Pkt.WriteShort((short)PubKeyDer.size());
+		Pkt.WriteBEUInt16(static_cast<UInt16>(PubKeyDer.size()));
 		Pkt.WriteBuf(PubKeyDer.data(), PubKeyDer.size());
-		Pkt.WriteShort(4);
-		Pkt.WriteInt((int)(intptr_t)this);  // Using 'this' as the cryptographic nonce, so that we don't have to generate one each time :)
+		Pkt.WriteBEInt16(4);
+		Pkt.WriteBEUInt32(static_cast<UInt32>(reinterpret_cast<uintptr_t>(this)));  // Using 'this' as the cryptographic nonce, so that we don't have to generate one each time :)
 		m_Client->SetUsername(Username);
 		return;
 	}
@@ -2389,7 +2390,7 @@ void cProtocol172::SendPacket(cPacketizer & a_Packet)
 	// Send the packet length
 	UInt32 PacketLen = static_cast<UInt32>(m_OutPacketBuffer.GetUsedSpace());
 
-	m_OutPacketLenBuffer.WriteVarInt(PacketLen);
+	m_OutPacketLenBuffer.WriteVarInt32(PacketLen);
 	m_OutPacketLenBuffer.ReadAll(DataToSend);
 	SendData(DataToSend.data(), DataToSend.size());
 	m_OutPacketLenBuffer.CommitRead();
@@ -2586,17 +2587,17 @@ void cProtocol172::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 	
 	if (a_Item.IsEmpty())
 	{
-		a_Pkt.WriteShort(-1);
+		a_Pkt.WriteBEInt16(-1);
 		return;
 	}
 	
-	a_Pkt.WriteShort(ItemType);
-	a_Pkt.WriteChar (a_Item.m_ItemCount);
-	a_Pkt.WriteShort(a_Item.m_ItemDamage);
+	a_Pkt.WriteBEInt16(ItemType);
+	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
+	a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
 	
 	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (a_Item.m_ItemType != E_ITEM_FIREWORK_ROCKET) && (a_Item.m_ItemType != E_ITEM_FIREWORK_STAR))
 	{
-		a_Pkt.WriteShort(-1);
+		a_Pkt.WriteBEInt16(-1);
 		return;
 	}
 
@@ -2772,21 +2773,21 @@ void cProtocol172::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 	{
 		Flags |= 0x20;
 	}
-	a_Pkt.WriteByte(0);  // Byte(0) + index 0
-	a_Pkt.WriteByte(Flags);
+	a_Pkt.WriteBEUInt8(0);  // Byte(0) + index 0
+	a_Pkt.WriteBEUInt8(Flags);
 	
 	switch (a_Entity.GetEntityType())
 	{
 		case cEntity::etPlayer: break;  // TODO?
 		case cEntity::etPickup:
 		{
-			a_Pkt.WriteByte((5 << 5) | 10);  // Slot(5) + index 10
+			a_Pkt.WriteBEUInt8((5 << 5) | 10);  // Slot(5) + index 10
 			WriteItem(a_Pkt, reinterpret_cast<const cPickup &>(a_Entity).GetItem());
 			break;
 		}
 		case cEntity::etMinecart:
 		{
-			a_Pkt.WriteByte(0x51);
+			a_Pkt.WriteBEUInt8(0x51);
 
 			// The following expression makes Minecarts shake more with less health or higher damage taken
 			// It gets half the maximum health, and takes it away from the current health minus the half health:
@@ -2796,11 +2797,11 @@ void cProtocol172::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 			Health: 1 | 3 - (1 - 3) = 5
 			*/
 			auto & Minecart = reinterpret_cast<const cMinecart &>(a_Entity);
-			a_Pkt.WriteInt((((a_Entity.GetMaxHealth() / 2) - (a_Entity.GetHealth() - (a_Entity.GetMaxHealth() / 2))) * Minecart.LastDamage()) * 4);
-			a_Pkt.WriteByte(0x52);
-			a_Pkt.WriteInt(1);  // Shaking direction, doesn't seem to affect anything
-			a_Pkt.WriteByte(0x73);
-			a_Pkt.WriteFloat(static_cast<float>(Minecart.LastDamage() + 10));  // Damage taken / shake effect multiplyer
+			a_Pkt.WriteBEInt32((((a_Entity.GetMaxHealth() / 2) - (a_Entity.GetHealth() - (a_Entity.GetMaxHealth() / 2))) * Minecart.LastDamage()) * 4);
+			a_Pkt.WriteBEUInt8(0x52);
+			a_Pkt.WriteBEInt32(1);  // Shaking direction, doesn't seem to affect anything
+			a_Pkt.WriteBEUInt8(0x73);
+			a_Pkt.WriteBEFloat(static_cast<float>(Minecart.LastDamage() + 10));  // Damage taken / shake effect multiplyer
 			
 			if (Minecart.GetPayload() == cMinecart::mpNone)
 			{
@@ -2808,20 +2809,20 @@ void cProtocol172::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 				const cItem & MinecartContent = RideableMinecart.GetContent();
 				if (!MinecartContent.IsEmpty())
 				{
-					a_Pkt.WriteByte(0x54);
+					a_Pkt.WriteBEUInt8(0x54);
 					int Content = MinecartContent.m_ItemType;
 					Content |= MinecartContent.m_ItemDamage << 8;
-					a_Pkt.WriteInt(Content);
-					a_Pkt.WriteByte(0x55);
-					a_Pkt.WriteInt(RideableMinecart.GetBlockHeight());
-					a_Pkt.WriteByte(0x56);
-					a_Pkt.WriteByte(1);
+					a_Pkt.WriteBEInt32(Content);
+					a_Pkt.WriteBEUInt8(0x55);
+					a_Pkt.WriteBEInt32(RideableMinecart.GetBlockHeight());
+					a_Pkt.WriteBEUInt8(0x56);
+					a_Pkt.WriteBEUInt8(1);
 				}
 			}
 			else if (Minecart.GetPayload() == cMinecart::mpFurnace)
 			{
-				a_Pkt.WriteByte(0x10);
-				a_Pkt.WriteByte(reinterpret_cast<const cMinecartWithFurnace &>(Minecart).IsFueled() ? 1 : 0);
+				a_Pkt.WriteBEUInt8(0x10);
+				a_Pkt.WriteBEUInt8(reinterpret_cast<const cMinecartWithFurnace &>(Minecart).IsFueled() ? 1 : 0);
 			}
 			break;
 		}  // case etMinecart
@@ -2833,13 +2834,13 @@ void cProtocol172::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 			{
 				case cProjectileEntity::pkArrow:
 				{
-					a_Pkt.WriteByte(0x10);
-					a_Pkt.WriteByte(reinterpret_cast<const cArrowEntity &>(a_Entity).IsCritical() ? 1 : 0);
+					a_Pkt.WriteBEUInt8(0x10);
+					a_Pkt.WriteBEUInt8(reinterpret_cast<const cArrowEntity &>(a_Entity).IsCritical() ? 1 : 0);
 					break;
 				}
 				case cProjectileEntity::pkFirework:
 				{
-					a_Pkt.WriteByte(0xa8);
+					a_Pkt.WriteBEUInt8(0xa8);
 					WriteItem(a_Pkt, reinterpret_cast<const cFireworkEntity &>(a_Entity).GetItem());
 					break;
 				}
@@ -2857,10 +2858,10 @@ void cProtocol172::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 		case cEntity::etItemFrame:
 		{
 			auto & Frame = reinterpret_cast<const cItemFrame &>(a_Entity);
-			a_Pkt.WriteByte(0xa2);
+			a_Pkt.WriteBEUInt8(0xa2);
 			WriteItem(a_Pkt, Frame.GetItem());
-			a_Pkt.WriteByte(0x03);
-			a_Pkt.WriteByte(Frame.GetItemRotation() / 2);
+			a_Pkt.WriteBEUInt8(0x03);
+			a_Pkt.WriteBEUInt8(Frame.GetItemRotation() / 2);
 			break;
 		}  // case etItemFrame
 
@@ -2881,36 +2882,36 @@ void cProtocol172::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 	{
 		case mtBat:
 		{
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(reinterpret_cast<const cBat &>(a_Mob).IsHanging() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(reinterpret_cast<const cBat &>(a_Mob).IsHanging() ? 1 : 0);
 			break;
 		}  // case mtBat
 		
 		case mtCreeper:
 		{
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(reinterpret_cast<const cCreeper &>(a_Mob).IsBlowing() ? 1 : 0);
-			a_Pkt.WriteByte(0x11);
-			a_Pkt.WriteByte(reinterpret_cast<const cCreeper &>(a_Mob).IsCharged() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(reinterpret_cast<const cCreeper &>(a_Mob).IsBlowing() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x11);
+			a_Pkt.WriteBEUInt8(reinterpret_cast<const cCreeper &>(a_Mob).IsCharged() ? 1 : 0);
 			break;
 		}  // case mtCreeper
 		
 		case mtEnderman:
 		{
 			auto & Enderman = reinterpret_cast<const cEnderman &>(a_Mob);
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte((Byte)(Enderman.GetCarriedBlock()));
-			a_Pkt.WriteByte(0x11);
-			a_Pkt.WriteByte((Byte)(Enderman.GetCarriedMeta()));
-			a_Pkt.WriteByte(0x12);
-			a_Pkt.WriteByte(Enderman.IsScreaming() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8((Byte)(Enderman.GetCarriedBlock()));
+			a_Pkt.WriteBEUInt8(0x11);
+			a_Pkt.WriteBEUInt8((Byte)(Enderman.GetCarriedMeta()));
+			a_Pkt.WriteBEUInt8(0x12);
+			a_Pkt.WriteBEUInt8(Enderman.IsScreaming() ? 1 : 0);
 			break;
 		}  // case mtEnderman
 		
 		case mtGhast:
 		{
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(reinterpret_cast<const cGhast &>(a_Mob).IsCharging());
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(reinterpret_cast<const cGhast &>(a_Mob).IsCharging());
 			break;
 		}  // case mtGhast
 		
@@ -2946,81 +2947,81 @@ void cProtocol172::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 			{
 				Flags |= 0x80;
 			}
-			a_Pkt.WriteByte(0x50);  // Int at index 16
-			a_Pkt.WriteInt(Flags);
-			a_Pkt.WriteByte(0x13);  // Byte at index 19
-			a_Pkt.WriteByte(static_cast<Byte>(Horse.GetHorseType()));
-			a_Pkt.WriteByte(0x54);  // Int at index 20
+			a_Pkt.WriteBEUInt8(0x50);  // Int at index 16
+			a_Pkt.WriteBEInt32(Flags);
+			a_Pkt.WriteBEUInt8(0x13);  // Byte at index 19
+			a_Pkt.WriteBEUInt8(static_cast<Byte>(Horse.GetHorseType()));
+			a_Pkt.WriteBEUInt8(0x54);  // Int at index 20
 			int Appearance = 0;
 			Appearance = Horse.GetHorseColor();
 			Appearance |= Horse.GetHorseStyle() << 8;
-			a_Pkt.WriteInt(Appearance);
-			a_Pkt.WriteByte(0x56);  // Int at index 22
-			a_Pkt.WriteInt(Horse.GetHorseArmour());
+			a_Pkt.WriteBEInt32(Appearance);
+			a_Pkt.WriteBEUInt8(0x56);  // Int at index 22
+			a_Pkt.WriteBEInt32(Horse.GetHorseArmour());
 			break;
 		}  // case mtHorse
 
 		case mtMagmaCube:
 		{
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(static_cast<Byte>(reinterpret_cast<const cMagmaCube &>(a_Mob).GetSize()));
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(static_cast<Byte>(reinterpret_cast<const cMagmaCube &>(a_Mob).GetSize()));
 			break;
 		}  // case mtMagmaCube
 		
 		case mtPig:
 		{
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(reinterpret_cast<const cPig &>(a_Mob).IsSaddled() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(reinterpret_cast<const cPig &>(a_Mob).IsSaddled() ? 1 : 0);
 			break;
 		}  // case mtPig
 		
 		case mtSheep:
 		{
-			a_Pkt.WriteByte(0x10);
+			a_Pkt.WriteBEUInt8(0x10);
 			auto & Sheep = reinterpret_cast<const cSheep &>(a_Mob);
 			Byte SheepMetadata = static_cast<Byte>(Sheep.GetFurColor() & 0x0f);
 			if (Sheep.IsSheared())
 			{
 				SheepMetadata |= 0x10;
 			}
-			a_Pkt.WriteByte(SheepMetadata);
+			a_Pkt.WriteBEUInt8(SheepMetadata);
 			break;
 		}  // case mtSheep
 		
 		case mtSkeleton:
 		{
-			a_Pkt.WriteByte(0x0d);
-			a_Pkt.WriteByte(reinterpret_cast<const cSkeleton &>(a_Mob).IsWither() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0d);
+			a_Pkt.WriteBEUInt8(reinterpret_cast<const cSkeleton &>(a_Mob).IsWither() ? 1 : 0);
 			break;
 		}  // case mtSkeleton
 		
 		case mtSlime:
 		{
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(static_cast<Byte>(reinterpret_cast<const cSlime &>(a_Mob).GetSize()));
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(static_cast<Byte>(reinterpret_cast<const cSlime &>(a_Mob).GetSize()));
 			break;
 		}  // case mtSlime
 		
 		case mtVillager:
 		{
-			a_Pkt.WriteByte(0x50);
-			a_Pkt.WriteInt(reinterpret_cast<const cVillager &>(a_Mob).GetVilType());
+			a_Pkt.WriteBEUInt8(0x50);
+			a_Pkt.WriteBEInt32(reinterpret_cast<const cVillager &>(a_Mob).GetVilType());
 			break;
 		}  // case mtVillager
 		
 		case mtWitch:
 		{
-			a_Pkt.WriteByte(0x15);
-			a_Pkt.WriteByte(reinterpret_cast<const cWitch &>(a_Mob).IsAngry() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x15);
+			a_Pkt.WriteBEUInt8(reinterpret_cast<const cWitch &>(a_Mob).IsAngry() ? 1 : 0);
 			break;
 		}  // case mtWitch
 
 		case mtWither:
 		{
-			a_Pkt.WriteByte(0x54);  // Int at index 20
-			a_Pkt.WriteInt(static_cast<int>(reinterpret_cast<const cWither &>(a_Mob).GetWitherInvulnerableTicks()));
-			a_Pkt.WriteByte(0x66);  // Float at index 6
-			a_Pkt.WriteFloat(static_cast<float>(a_Mob.GetHealth()));
+			a_Pkt.WriteBEUInt8(0x54);  // Int at index 20
+			a_Pkt.WriteBEInt32(static_cast<int>(reinterpret_cast<const cWither &>(a_Mob).GetWitherInvulnerableTicks()));
+			a_Pkt.WriteBEUInt8(0x66);  // Float at index 6
+			a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
 			break;
 		}  // case mtWither
 		
@@ -3040,27 +3041,27 @@ void cProtocol172::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 			{
 				WolfStatus |= 0x4;
 			}
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(WolfStatus);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(WolfStatus);
 
-			a_Pkt.WriteByte(0x72);
-			a_Pkt.WriteFloat(static_cast<float>(a_Mob.GetHealth()));
-			a_Pkt.WriteByte(0x13);
-			a_Pkt.WriteByte(Wolf.IsBegging() ? 1 : 0);
-			a_Pkt.WriteByte(0x14);
-			a_Pkt.WriteByte(static_cast<Byte>(Wolf.GetCollarColor()));
+			a_Pkt.WriteBEUInt8(0x72);
+			a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
+			a_Pkt.WriteBEUInt8(0x13);
+			a_Pkt.WriteBEUInt8(Wolf.IsBegging() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x14);
+			a_Pkt.WriteBEUInt8(static_cast<Byte>(Wolf.GetCollarColor()));
 			break;
 		}  // case mtWolf
 		
 		case mtZombie:
 		{
 			auto & Zombie = reinterpret_cast<const cZombie &>(a_Mob);
-			a_Pkt.WriteByte(0x0c);
-			a_Pkt.WriteByte(Zombie.IsBaby() ? 1 : 0);
-			a_Pkt.WriteByte(0x0d);
-			a_Pkt.WriteByte(Zombie.IsVillagerZombie() ? 1 : 0);
-			a_Pkt.WriteByte(0x0e);
-			a_Pkt.WriteByte(Zombie.IsConverting() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEUInt8(Zombie.IsBaby() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0d);
+			a_Pkt.WriteBEUInt8(Zombie.IsVillagerZombie() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0e);
+			a_Pkt.WriteBEUInt8(Zombie.IsConverting() ? 1 : 0);
 			break;
 		}  // case mtZombie
 
@@ -3074,10 +3075,10 @@ void cProtocol172::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 	// Custom name:
 	if (a_Mob.HasCustomName())
 	{
-		a_Pkt.WriteByte(0x8a);
+		a_Pkt.WriteBEUInt8(0x8a);
 		a_Pkt.WriteString(a_Mob.GetCustomName());
-		a_Pkt.WriteByte(0x0b);
-		a_Pkt.WriteByte(a_Mob.IsCustomNameAlwaysVisible() ? 1 : 0);
+		a_Pkt.WriteBEUInt8(0x0b);
+		a_Pkt.WriteBEUInt8(a_Mob.IsCustomNameAlwaysVisible() ? 1 : 0);
 	}
 }
 
@@ -3090,7 +3091,7 @@ void cProtocol172::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_
 	if (!a_Entity.IsMob())
 	{
 		// No properties for anything else than mobs
-		a_Pkt.WriteInt(0);
+		a_Pkt.WriteBEInt32(0);
 		return;
 	}
 
@@ -3098,7 +3099,7 @@ void cProtocol172::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_
 
 	// TODO: Send properties and modifiers based on the mob type
 	
-	a_Pkt.WriteInt(0);  // NumProperties
+	a_Pkt.WriteBEInt32(0);  // NumProperties
 }
 
 
@@ -3121,7 +3122,7 @@ void cProtocol176::SendPlayerSpawn(const cPlayer & a_Player)
 {
 	// Called to spawn another player for the client
 	cPacketizer Pkt(*this, 0x0c);  // Spawn Player packet
-	Pkt.WriteVarInt(a_Player.GetUniqueID());
+	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 	Pkt.WriteString(cMojangAPI::MakeUUIDDashed(a_Player.GetClientHandle()->GetUUID()));
 	if (a_Player.HasCustomName())
 	{
@@ -3133,7 +3134,7 @@ void cProtocol176::SendPlayerSpawn(const cPlayer & a_Player)
 	}
 
 	const Json::Value & Properties = a_Player.GetClientHandle()->GetProperties();
-	Pkt.WriteVarInt(Properties.size());
+	Pkt.WriteVarInt32(Properties.size());
 
 	for (Json::Value::iterator itr = Properties.begin(), end = Properties.end(); itr != end; ++itr)
 	{
@@ -3148,10 +3149,10 @@ void cProtocol176::SendPlayerSpawn(const cPlayer & a_Player)
 	Pkt.WriteByteAngle(a_Player.GetYaw());
 	Pkt.WriteByteAngle(a_Player.GetPitch());
 	short ItemType = a_Player.GetEquippedItem().IsEmpty() ? 0 : a_Player.GetEquippedItem().m_ItemType;
-	Pkt.WriteShort(ItemType);
-	Pkt.WriteByte((3 << 5) | 6);  // Metadata: float + index 6
-	Pkt.WriteFloat((float)a_Player.GetHealth());
-	Pkt.WriteByte(0x7f);  // Metadata: end
+	Pkt.WriteBEInt16(ItemType);
+	Pkt.WriteBEUInt8((3 << 5) | 6);  // Metadata: float + index 6
+	Pkt.WriteBEFloat(static_cast<float>(a_Player.GetHealth()));
+	Pkt.WriteBEUInt8(0x7f);  // Metadata: end
 }
 
 

--- a/src/Protocol/Protocol17x.cpp
+++ b/src/Protocol/Protocol17x.cpp
@@ -192,7 +192,7 @@ void cProtocol172::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, cha
 
 
 
-void cProtocol172::SendBlockBreakAnim(int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
+void cProtocol172::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	
@@ -2133,7 +2133,7 @@ void cProtocol172::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
 
 void cProtocol172::HandlePacketSlotSelect(cByteBuffer & a_ByteBuffer)
 {
-	HANDLE_READ(a_ByteBuffer, ReadBEUInt16, UInt16, SlotNum);
+	HANDLE_READ(a_ByteBuffer, ReadBEInt16, Int16, SlotNum);
 	m_Client->HandleSlotSelected(SlotNum);
 }
 

--- a/src/Protocol/Protocol17x.cpp
+++ b/src/Protocol/Protocol17x.cpp
@@ -166,8 +166,8 @@ void cProtocol172::SendAttachEntity(const cEntity & a_Entity, const cEntity * a_
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1b);  // Attach Entity packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
-	Pkt.WriteInt((a_Vehicle != nullptr) ? a_Vehicle->GetUniqueID() : 0);
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32((a_Vehicle != nullptr) ? a_Vehicle->GetUniqueID() : 0);
 	Pkt.WriteBool(false);
 }
 
@@ -197,7 +197,7 @@ void cProtocol172::SendBlockBreakAnim(int a_EntityID, int a_BlockX, int a_BlockY
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x25);  // Block Break Animation packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_EntityID));
+	Pkt.WriteVarInt(a_EntityID);
 	Pkt.WriteInt(a_BlockX);
 	Pkt.WriteInt(a_BlockY);
 	Pkt.WriteInt(a_BlockZ);
@@ -297,8 +297,8 @@ void cProtocol172::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0d);  // Collect Item packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
-	Pkt.WriteInt(a_Player.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Player.GetUniqueID());
 }
 
 
@@ -311,7 +311,7 @@ void cProtocol172::SendDestroyEntity(const cEntity & a_Entity)
 	
 	cPacketizer Pkt(*this, 0x13);  // Destroy Entities packet
 	Pkt.WriteByte(1);
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 }
 
 
@@ -364,7 +364,7 @@ void cProtocol172::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, in
 	ASSERT((a_Amplifier >= 0) && (a_Amplifier < 256));
 	
 	cPacketizer Pkt(*this, 0x1D);  // Entity Effect packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByte(static_cast<Byte>(a_EffectID));
 	Pkt.WriteByte(static_cast<Byte>(a_Amplifier));
 	Pkt.WriteShort(a_Duration);
@@ -379,7 +379,7 @@ void cProtocol172::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x04);  // Entity Equipment packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteShort(a_SlotNum);
 	Pkt.WriteItem(a_Item);
 }
@@ -393,7 +393,7 @@ void cProtocol172::SendEntityHeadLook(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x19);  // Entity Head Look packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetHeadYaw());
 }
 
@@ -406,7 +406,7 @@ void cProtocol172::SendEntityLook(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x16);  // Entity Look packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 }
@@ -420,7 +420,7 @@ void cProtocol172::SendEntityMetadata(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteEntityMetadata(a_Entity);
 	Pkt.WriteByte(0x7f);  // The termination byte
 }
@@ -434,7 +434,7 @@ void cProtocol172::SendEntityProperties(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x20);  // Entity Properties packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteEntityProperties(a_Entity);
 }
 
@@ -447,7 +447,7 @@ void cProtocol172::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x15);  // Entity Relative Move packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteChar(a_RelX);
 	Pkt.WriteChar(a_RelY);
 	Pkt.WriteChar(a_RelZ);
@@ -462,7 +462,7 @@ void cProtocol172::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, 
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x17);  // Entity Look And Relative Move packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteChar(a_RelX);
 	Pkt.WriteChar(a_RelY);
 	Pkt.WriteChar(a_RelZ);
@@ -479,7 +479,7 @@ void cProtocol172::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1a);  // Entity Status packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteChar(a_Status);
 }
 
@@ -492,11 +492,11 @@ void cProtocol172::SendEntityVelocity(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x12);  // Entity Velocity packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	// 400 = 8000 / 20 ... Conversion from our speed in m/s to 8000 m/tick
-	Pkt.WriteShort((short)(a_Entity.GetSpeedX() * 400));
-	Pkt.WriteShort((short)(a_Entity.GetSpeedY() * 400));
-	Pkt.WriteShort((short)(a_Entity.GetSpeedZ() * 400));
+	Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedX() * 400));
+	Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedY() * 400));
+	Pkt.WriteShort(static_cast<short>(a_Entity.GetSpeedZ() * 400));
 }
 
 
@@ -593,7 +593,7 @@ void cProtocol172::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 	{
 		cServer * Server = cRoot::Get()->GetServer();
 		cPacketizer Pkt(*this, 0x01);  // Join Game packet
-		Pkt.WriteInt(a_Player.GetUniqueID());
+		Pkt.WriteUInt32(a_Player.GetUniqueID());
 		Pkt.WriteByte(static_cast<Byte>(a_Player.GetEffectiveGameMode()) | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
 		Pkt.WriteChar(static_cast<char>(a_World.GetDimension()));
 		Pkt.WriteByte(2);  // TODO: Difficulty (set to Normal)
@@ -639,7 +639,7 @@ void cProtocol172::SendPaintingSpawn(const cPainting & a_Painting)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x10);  // Spawn Painting packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_Painting.GetUniqueID()));
+	Pkt.WriteVarInt(a_Painting.GetUniqueID());
 	Pkt.WriteString(a_Painting.GetName().c_str());
 	Pkt.WriteInt(static_cast<int>(a_Painting.GetPosX()));
 	Pkt.WriteInt(static_cast<int>(a_Painting.GetPosY()));
@@ -651,7 +651,7 @@ void cProtocol172::SendPaintingSpawn(const cPainting & a_Painting)
 
 
 
-void cProtocol172::SendMapColumn(int a_ID, int a_X, int a_Y, const Byte * a_Colors, unsigned int a_Length, unsigned int m_Scale)
+void cProtocol172::SendMapColumn(int a_MapID, int a_X, int a_Y, const Byte * a_Colors, unsigned int a_Length, unsigned int m_Scale)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	ASSERT(a_Length + 3 <= USHRT_MAX);
@@ -659,7 +659,7 @@ void cProtocol172::SendMapColumn(int a_ID, int a_X, int a_Y, const Byte * a_Colo
 	ASSERT((a_Y >= 0) && (a_Y < 256));
 	
 	cPacketizer Pkt(*this, 0x34);
-	Pkt.WriteVarInt(static_cast<UInt32>(a_ID));
+	Pkt.WriteVarInt(static_cast<UInt32>(a_MapID));
 	Pkt.WriteShort (static_cast<short>(3 + a_Length));
 
 	Pkt.WriteByte(0);
@@ -673,13 +673,13 @@ void cProtocol172::SendMapColumn(int a_ID, int a_X, int a_Y, const Byte * a_Colo
 
 
 
-void cProtocol172::SendMapDecorators(int a_ID, const cMapDecoratorList & a_Decorators, unsigned int m_Scale)
+void cProtocol172::SendMapDecorators(int a_MapID, const cMapDecoratorList & a_Decorators, unsigned int m_Scale)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	ASSERT(1 + 3 * a_Decorators.size() < USHRT_MAX);
 	
 	cPacketizer Pkt(*this, 0x34);
-	Pkt.WriteVarInt(static_cast<UInt32>(a_ID));
+	Pkt.WriteVarInt(static_cast<UInt32>(a_MapID));
 	Pkt.WriteShort (static_cast<short>(1 + (3 * a_Decorators.size())));
 
 	Pkt.WriteByte(1);
@@ -698,13 +698,13 @@ void cProtocol172::SendMapDecorators(int a_ID, const cMapDecoratorList & a_Decor
 
 
 
-void cProtocol172::SendMapInfo(int a_ID, unsigned int a_Scale)
+void cProtocol172::SendMapInfo(int a_MapID, unsigned int a_Scale)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	ASSERT(a_Scale < 256);
 	
 	cPacketizer Pkt(*this, 0x34);
-	Pkt.WriteVarInt(static_cast<UInt32>(a_ID));
+	Pkt.WriteVarInt(static_cast<UInt32>(a_MapID));
 	Pkt.WriteShort (2);
 
 	Pkt.WriteByte(2);
@@ -721,7 +721,7 @@ void cProtocol172::SendPickupSpawn(const cPickup & a_Pickup)
 	
 	{
 		cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
-		Pkt.WriteVarInt(static_cast<UInt32>(a_Pickup.GetUniqueID()));
+		Pkt.WriteVarInt(a_Pickup.GetUniqueID());
 		Pkt.WriteByte(2);  // Type = Pickup
 		Pkt.WriteFPInt(a_Pickup.GetPosX());
 		Pkt.WriteFPInt(a_Pickup.GetPosY());
@@ -732,7 +732,7 @@ void cProtocol172::SendPickupSpawn(const cPickup & a_Pickup)
 	}
 	{
 		cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
-		Pkt.WriteInt(a_Pickup.GetUniqueID());
+		Pkt.WriteUInt32(a_Pickup.GetUniqueID());
 		Pkt.WriteByte((0x05 << 5) | 10);  // Slot type + index 10
 		Pkt.WriteItem(a_Pickup.GetItem());
 		Pkt.WriteByte(0x7f);  // End of metadata
@@ -777,7 +777,7 @@ void cProtocol172::SendEntityAnimation(const cEntity & a_Entity, char a_Animatio
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0b);  // Animation packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_Entity.GetUniqueID()));
+	Pkt.WriteVarInt(a_Entity.GetUniqueID());
 	Pkt.WriteChar(a_Animation);
 }
 
@@ -870,7 +870,7 @@ void cProtocol172::SendPlayerMaxSpeed(void)
 	
 	cPacketizer Pkt(*this, 0x20);  // Entity Properties
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteInt(Player->GetUniqueID());
+	Pkt.WriteUInt32(Player->GetUniqueID());
 	Pkt.WriteInt(1);  // Count
 	Pkt.WriteString("generic.movementSpeed");
 	// The default game speed is 0.1, multiply that value by the relative speed:
@@ -931,7 +931,7 @@ void cProtocol172::SendPlayerSpawn(const cPlayer & a_Player)
 	
 	// Called to spawn another player for the client
 	cPacketizer Pkt(*this, 0x0c);  // Spawn Player packet
-	Pkt.WriteVarInt((UInt32) a_Player.GetUniqueID());
+	Pkt.WriteVarInt(a_Player.GetUniqueID());
 	Pkt.WriteString(cMojangAPI::MakeUUIDDashed(a_Player.GetClientHandle()->GetUUID()));
 	if (a_Player.HasCustomName())
 	{
@@ -977,7 +977,7 @@ void cProtocol172::SendRemoveEntityEffect(const cEntity & a_Entity, int a_Effect
 	ASSERT((a_EffectID >= 0) && (a_EffectID < 256));
 	
 	cPacketizer Pkt(*this, 0x1e);
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByte(static_cast<Byte>(a_EffectID));
 }
 
@@ -1027,7 +1027,7 @@ void cProtocol172::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 	ASSERT((a_ExpOrb.GetReward() >= 0) && (a_ExpOrb.GetReward() < SHRT_MAX));
 	
 	cPacketizer Pkt(*this, 0x11);
-	Pkt.WriteVarInt(static_cast<UInt32>(a_ExpOrb.GetUniqueID()));
+	Pkt.WriteVarInt(a_ExpOrb.GetUniqueID());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosX());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosY());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosZ());
@@ -1124,7 +1124,7 @@ void cProtocol172::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_FallingBlock.GetUniqueID()));
+	Pkt.WriteVarInt(a_FallingBlock.GetUniqueID());
 	Pkt.WriteByte(70);  // Falling block
 	Pkt.WriteFPInt(a_FallingBlock.GetPosX());
 	Pkt.WriteFPInt(a_FallingBlock.GetPosY());
@@ -1146,7 +1146,7 @@ void cProtocol172::SendSpawnMob(const cMonster & a_Mob)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0f);  // Spawn Mob packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_Mob.GetUniqueID()));
+	Pkt.WriteVarInt(a_Mob.GetUniqueID());
 	Pkt.WriteByte((Byte)a_Mob.GetMobType());
 	Pkt.WriteFPInt(a_Mob.GetPosX());
 	Pkt.WriteFPInt(a_Mob.GetPosY());
@@ -1170,7 +1170,7 @@ void cProtocol172::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, 
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_Entity.GetUniqueID()));
+	Pkt.WriteVarInt(a_Entity.GetUniqueID());
 	Pkt.WriteChar(a_ObjectType);
 	Pkt.WriteFPInt(a_Entity.GetPosX());
 	Pkt.WriteFPInt(a_Entity.GetPosY());
@@ -1195,7 +1195,7 @@ void cProtocol172::SendSpawnVehicle(const cEntity & a_Vehicle, char a_VehicleTyp
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_Vehicle.GetUniqueID()));
+	Pkt.WriteVarInt(a_Vehicle.GetUniqueID());
 	Pkt.WriteChar(a_VehicleType);
 	Pkt.WriteFPInt(a_Vehicle.GetPosX());
 	Pkt.WriteFPInt(a_Vehicle.GetPosY());
@@ -1258,7 +1258,7 @@ void cProtocol172::SendTeleportEntity(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x18);
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteFPInt(a_Entity.GetPosX());
 	Pkt.WriteFPInt(a_Entity.GetPosY());
 	Pkt.WriteFPInt(a_Entity.GetPosZ());
@@ -1371,11 +1371,12 @@ void cProtocol172::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, cons
 void cProtocol172::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	ASSERT(m_State == 3);  // In game mode?
+	ASSERT((a_BlockY >= 0) && (a_BlockY < cChunkDef::Height));
 	
 	cPacketizer Pkt(*this, 0x0a);
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteInt(a_BlockX);
-	Pkt.WriteByte((Byte)a_BlockY);
+	Pkt.WriteByte(static_cast<Byte>(a_BlockY));
 	Pkt.WriteInt(a_BlockZ);
 }
 
@@ -1563,7 +1564,7 @@ void cProtocol172::AddReceivedData(const char * a_Data, size_t a_Size)
 				bb.ReadAll(Packet);
 				Packet.resize(Packet.size() - 1);  // Drop the final NUL pushed there for over-read detection
 				AString Out;
-				CreateHexDump(Out, Packet.data(), (int)Packet.size(), 24);
+				CreateHexDump(Out, Packet.data(), Packet.size(), 24);
 				LOGD("Packet contents:\n%s", Out.c_str());
 			#endif  // _DEBUG
 			
@@ -1797,7 +1798,7 @@ void cProtocol172::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffe
 
 	// Decrypt EncNonce using privkey
 	cRsaPrivateKey & rsaDecryptor = cRoot::Get()->GetServer()->GetPrivateKey();
-	Int32 DecryptedNonce[MAX_ENC_LEN / sizeof(Int32)];
+	UInt32 DecryptedNonce[MAX_ENC_LEN / sizeof(UInt32)];
 	int res = rsaDecryptor.Decrypt(
 		reinterpret_cast<const Byte *>(EncNonce.data()), EncNonce.size(),
 		reinterpret_cast<Byte *>(DecryptedNonce), sizeof(DecryptedNonce)
@@ -1808,7 +1809,7 @@ void cProtocol172::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffe
 		m_Client->Kick("Hacked client");
 		return;
 	}
-	if (ntohl(DecryptedNonce[0]) != (unsigned)(uintptr_t)this)
+	if (ntohl(DecryptedNonce[0]) != static_cast<UInt32>(reinterpret_cast<uintptr_t>(this)))
 	{
 		LOGD("Bad nonce value");
 		m_Client->Kick("Hacked client");
@@ -1817,7 +1818,10 @@ void cProtocol172::HandlePacketLoginEncryptionResponse(cByteBuffer & a_ByteBuffe
 	
 	// Decrypt the symmetric encryption key using privkey:
 	Byte DecryptedKey[MAX_ENC_LEN];
-	res = rsaDecryptor.Decrypt((const Byte *)EncKey.data(), EncKey.size(), DecryptedKey, sizeof(DecryptedKey));
+	res = rsaDecryptor.Decrypt(
+		reinterpret_cast<const Byte *>(EncKey.data()), EncKey.size(),
+		DecryptedKey, sizeof(DecryptedKey)
+	);
 	if (res != 16)
 	{
 		LOGD("Bad key length");
@@ -1900,7 +1904,7 @@ void cProtocol172::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, BlockX);
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, BlockY);
 	HANDLE_READ(a_ByteBuffer, ReadBEInt32, Int32, BlockZ);
-	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Face);
+	HANDLE_READ(a_ByteBuffer, ReadBEInt8,  Int8,  Face);
 	cItem Item;
 	ReadItem(a_ByteBuffer, Item);
 
@@ -2102,7 +2106,7 @@ void cProtocol172::HandlePacketPluginMessage(cByteBuffer & a_ByteBuffer)
 	if (Length != a_ByteBuffer.GetReadableSpace() - 1)
 	{
 		LOGD("Invalid plugin message packet, payload length doesn't match packet length (exp %u, got %u)",
-			a_ByteBuffer.GetReadableSpace() - 1, Length
+			static_cast<unsigned>(a_ByteBuffer.GetReadableSpace() - 1), Length
 		);
 		return;
 	}
@@ -3130,7 +3134,7 @@ void cProtocol176::SendPlayerSpawn(const cPlayer & a_Player)
 {
 	// Called to spawn another player for the client
 	cPacketizer Pkt(*this, 0x0c);  // Spawn Player packet
-	Pkt.WriteVarInt(static_cast<UInt32>(a_Player.GetUniqueID()));
+	Pkt.WriteVarInt(a_Player.GetUniqueID());
 	Pkt.WriteString(cMojangAPI::MakeUUIDDashed(a_Player.GetClientHandle()->GetUUID()));
 	if (a_Player.HasCustomName())
 	{

--- a/src/Protocol/Protocol17x.h
+++ b/src/Protocol/Protocol17x.h
@@ -161,22 +161,22 @@ protected:
 		
 		void WriteByte(Byte a_Value)
 		{
-			m_Out.WriteByte(a_Value);
+			m_Out.WriteBEUInt8(a_Value);
 		}
 		
 		void WriteChar(char a_Value)
 		{
-			m_Out.WriteChar(a_Value);
+			m_Out.WriteBEInt8(a_Value);
 		}
 		
 		void WriteShort(short a_Value)
 		{
-			m_Out.WriteBEShort(a_Value);
+			m_Out.WriteBEInt16(a_Value);
 		}
 		
-		void WriteInt(int a_Value)
+		void WriteInt(Int32 a_Value)
 		{
-			m_Out.WriteBEInt(a_Value);
+			m_Out.WriteBEInt32(a_Value);
 		}
 		
 		void WriteInt64(Int64 a_Value)
@@ -297,7 +297,7 @@ protected:
 	
 	/** Parses Vanilla plugin messages into specific ClientHandle calls.
 	The message payload is still in the bytebuffer, to be read by this function. */
-	void HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel, short a_PayloadLength);
+	void HandleVanillaPluginMessage(cByteBuffer & a_ByteBuffer, const AString & a_Channel, UInt16 a_PayloadLength);
 	
 	/** Sends the data to the client, encrypting them if needed. */
 	virtual void SendData(const char * a_Data, size_t a_Size) override;
@@ -312,6 +312,9 @@ protected:
 	
 	void StartEncryption(const Byte * a_Key);
 
+	/** Converts the BlockFace received by the protocol into eBlockFace constants.
+	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
+	eBlockFace FaceIntToBlockFace(Int8 a_FaceInt);
 } ;
 
 

--- a/src/Protocol/Protocol17x.h
+++ b/src/Protocol/Protocol17x.h
@@ -63,7 +63,7 @@ public:
 	/** Sending stuff to clients (alphabetically sorted): */
 	virtual void SendAttachEntity               (const cEntity & a_Entity, const cEntity * a_Vehicle) override;
 	virtual void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType) override;
-	virtual void SendBlockBreakAnim	            (int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) override;
+	virtual void SendBlockBreakAnim	            (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) override;
 	virtual void SendBlockChange                (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) override;
 	virtual void SendBlockChanges               (int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes) override;
 	virtual void SendChat                       (const AString & a_Message) override;

--- a/src/Protocol/Protocol17x.h
+++ b/src/Protocol/Protocol17x.h
@@ -140,94 +140,6 @@ public:
 
 protected:
 
-	/** Composes individual packets in the protocol's m_OutPacketBuffer; sends them upon being destructed */
-	class cPacketizer
-	{
-	public:
-		cPacketizer(cProtocol172 & a_Protocol, UInt32 a_PacketType) :
-			m_Protocol(a_Protocol),
-			m_Out(a_Protocol.m_OutPacketBuffer),
-			m_Lock(a_Protocol.m_CSPacket)
-		{
-			m_Out.WriteVarInt(a_PacketType);
-		}
-		
-		~cPacketizer();
-
-		void WriteBool(bool a_Value)
-		{
-			m_Out.WriteBool(a_Value);
-		}
-		
-		void WriteByte(Byte a_Value)
-		{
-			m_Out.WriteBEUInt8(a_Value);
-		}
-		
-		void WriteChar(char a_Value)
-		{
-			m_Out.WriteBEInt8(a_Value);
-		}
-		
-		void WriteShort(short a_Value)
-		{
-			m_Out.WriteBEInt16(a_Value);
-		}
-		
-		void WriteInt(Int32 a_Value)
-		{
-			m_Out.WriteBEInt32(a_Value);
-		}
-		
-		void WriteUInt32(UInt32 a_Value)
-		{
-			m_Out.WriteBEUInt32(a_Value);
-		}
-		
-		void WriteInt64(Int64 a_Value)
-		{
-			m_Out.WriteBEInt64(a_Value);
-		}
-		
-		void WriteFloat(float a_Value)
-		{
-			m_Out.WriteBEFloat(a_Value);
-		}
-		
-		void WriteDouble(double a_Value)
-		{
-			m_Out.WriteBEDouble(a_Value);
-		}
-		
-		void WriteVarInt(UInt32 a_Value)
-		{
-			m_Out.WriteVarInt(a_Value);
-		}
-		
-		void WriteString(const AString & a_Value)
-		{
-			m_Out.WriteVarUTF8String(a_Value);
-		}
-		
-		void WriteBuf(const char * a_Data, size_t a_Size)
-		{
-			m_Out.Write(a_Data, a_Size);
-		}
-		
-		void WriteItem(const cItem & a_Item);
-		void WriteByteAngle(double a_Angle);  // Writes the specified angle using a single byte
-		void WriteFPInt(double a_Value);  // Writes the double value as a 27:5 fixed-point integer
-		void WriteEntityMetadata(const cEntity & a_Entity);  // Writes the metadata for the specified entity, not including the terminating 0x7f
-		void WriteMobMetadata(const cMonster & a_Mob);  // Writes the mob-specific metadata for the specified mob
-		void WriteEntityProperties(const cEntity & a_Entity);  // Writes the entity properties for the specified entity, including the Count field
-		void WriteBlockEntity(const cBlockEntity & a_BlockEntity);
-		
-	protected:
-		cProtocol172 & m_Protocol;
-		cByteBuffer & m_Out;
-		cCSLock m_Lock;
-	} ;
-
 	AString m_ServerAddress;
 	
 	UInt16 m_ServerPort;
@@ -239,12 +151,6 @@ protected:
 
 	/** Buffer for the received data */
 	cByteBuffer m_ReceivedData;
-	
-	/** Buffer for composing the outgoing packets, through cPacketizer */
-	cByteBuffer m_OutPacketBuffer;
-	
-	/** Buffer for composing packet length (so that each cPacketizer instance doesn't allocate a new cPacketBuffer) */
-	cByteBuffer m_OutPacketLenBuffer;
 	
 	bool m_IsEncrypted;
 	
@@ -307,6 +213,9 @@ protected:
 	/** Sends the data to the client, encrypting them if needed. */
 	virtual void SendData(const char * a_Data, size_t a_Size) override;
 
+	/** Sends the packet to the client. Called by the cPacketizer's destructor. */
+	virtual void SendPacket(cPacketizer & a_Packet) override;
+
 	void SendCompass(const cWorld & a_World);
 	
 	/** Reads an item out of the received data, sets a_Item to the values read. Returns false if not enough received data */
@@ -320,6 +229,21 @@ protected:
 	/** Converts the BlockFace received by the protocol into eBlockFace constants.
 	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
 	eBlockFace FaceIntToBlockFace(Int8 a_FaceInt);
+
+	/** Writes the item data into a packet. */
+	void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item);
+
+	/** Writes the metadata for the specified entity, not including the terminating 0x7f. */
+	void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity);
+
+	/** Writes the mob-specific metadata for the specified mob */
+	void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob);
+
+	/** Writes the entity properties for the specified entity, including the Count field. */
+	void WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity);
+
+	/** Writes the block entity data for the specified block entity into the packet. */
+	void WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_BlockEntity);
 } ;
 
 

--- a/src/Protocol/Protocol17x.h
+++ b/src/Protocol/Protocol17x.h
@@ -179,6 +179,11 @@ protected:
 			m_Out.WriteBEInt32(a_Value);
 		}
 		
+		void WriteUInt32(UInt32 a_Value)
+		{
+			m_Out.WriteBEUInt32(a_Value);
+		}
+		
 		void WriteInt64(Int64 a_Value)
 		{
 			m_Out.WriteBEInt64(a_Value);

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -161,8 +161,8 @@ void cProtocol180::SendAttachEntity(const cEntity & a_Entity, const cEntity * a_
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1b);  // Attach Entity packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteUInt32((a_Vehicle != nullptr) ? a_Vehicle->GetUniqueID() : 0);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt32((a_Vehicle != nullptr) ? a_Vehicle->GetUniqueID() : 0);
 	Pkt.WriteBool(false);
 }
 
@@ -175,10 +175,10 @@ void cProtocol180::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, cha
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x24);  // Block Action packet
-	Pkt.WritePosition(a_BlockX, a_BlockY, a_BlockZ);
-	Pkt.WriteByte(a_Byte1);
-	Pkt.WriteByte(a_Byte2);
-	Pkt.WriteVarInt(a_BlockType);
+	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
+	Pkt.WriteBEInt8(a_Byte1);
+	Pkt.WriteBEInt8(a_Byte2);
+	Pkt.WriteVarInt32(a_BlockType);
 }
 
 
@@ -190,9 +190,9 @@ void cProtocol180::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_Blo
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x25);  // Block Break Animation packet
-	Pkt.WriteVarInt(a_EntityID);
-	Pkt.WritePosition(a_BlockX, a_BlockY, a_BlockZ);
-	Pkt.WriteChar(a_Stage);
+	Pkt.WriteVarInt32(a_EntityID);
+	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
+	Pkt.WriteBEInt8(a_Stage);
 }
 
 
@@ -204,8 +204,8 @@ void cProtocol180::SendBlockChange(int a_BlockX, int a_BlockY, int a_BlockZ, BLO
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, 0x23);  // Block Change packet
-	Pkt.WritePosition(a_BlockX, a_BlockY, a_BlockZ);
-	Pkt.WriteVarInt(((UInt32)a_BlockType << 4) | ((UInt32)a_BlockMeta & 15));
+	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
+	Pkt.WriteVarInt32(((UInt32)a_BlockType << 4) | ((UInt32)a_BlockMeta & 15));
 }
 
 
@@ -217,14 +217,14 @@ void cProtocol180::SendBlockChanges(int a_ChunkX, int a_ChunkZ, const sSetBlockV
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, 0x22);  // Multi Block Change packet
-	Pkt.WriteInt(a_ChunkX);
-	Pkt.WriteInt(a_ChunkZ);
-	Pkt.WriteVarInt((UInt32)a_Changes.size());
+	Pkt.WriteBEInt32(a_ChunkX);
+	Pkt.WriteBEInt32(a_ChunkZ);
+	Pkt.WriteVarInt32((UInt32)a_Changes.size());
 	for (sSetBlockVector::const_iterator itr = a_Changes.begin(), end = a_Changes.end(); itr != end; ++itr)
 	{
-		short Coords = (short) (itr->m_RelY | (itr->m_RelZ << 8) | (itr->m_RelX << 12));
-		Pkt.WriteShort(Coords);
-		Pkt.WriteVarInt((itr->m_BlockType & 0xFFF) << 4 | (itr->m_BlockMeta & 0xF));
+		Int16 Coords = static_cast<Int16>(itr->m_RelY | (itr->m_RelZ << 8) | (itr->m_RelX << 12));
+		Pkt.WriteBEInt16(Coords);
+		Pkt.WriteVarInt32((itr->m_BlockType & 0xFFF) << 4 | (itr->m_BlockMeta & 0xF));
 	}  // for itr - a_Changes[]
 }
 
@@ -238,7 +238,7 @@ void cProtocol180::SendChat(const AString & a_Message)
 	
 	cPacketizer Pkt(*this, 0x02);  // Chat Message packet
 	Pkt.WriteString(Printf("{\"text\":\"%s\"}", EscapeString(a_Message).c_str()));
-	Pkt.WriteChar(0);
+	Pkt.WriteBEInt8(0);
 }
 
 
@@ -255,7 +255,7 @@ void cProtocol180::SendChat(const cCompositeChat & a_Message)
 	// Send the message to the client:
 	cPacketizer Pkt(*this, 0x02);
 	Pkt.WriteString(a_Message.CreateJsonString(ShouldUseChatPrefixes));
-	Pkt.WriteChar(0);
+	Pkt.WriteBEInt8(0);
 }
 
 
@@ -283,8 +283,8 @@ void cProtocol180::SendCollectEntity(const cEntity & a_Entity, const cPlayer & a
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0d);  // Collect Item packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteVarInt(a_Player.GetUniqueID());
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 }
 
 
@@ -296,8 +296,8 @@ void cProtocol180::SendDestroyEntity(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x13);  // Destroy Entities packet
-	Pkt.WriteVarInt(1);
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(1);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 }
 
 
@@ -334,7 +334,7 @@ void cProtocol180::SendEditSign(int a_BlockX, int a_BlockY, int a_BlockZ)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x36);  // Sign Editor Open packet
-	Pkt.WritePosition(a_BlockX, a_BlockY, a_BlockZ);
+	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 }
 
 
@@ -346,10 +346,10 @@ void cProtocol180::SendEntityEffect(const cEntity & a_Entity, int a_EffectID, in
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1D);  // Entity Effect packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteByte(a_EffectID);
-	Pkt.WriteByte(a_Amplifier);
-	Pkt.WriteVarInt((UInt32)a_Duration);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_EffectID));
+	Pkt.WriteBEUInt8(static_cast<UInt8>(a_Amplifier));
+	Pkt.WriteVarInt32((UInt32)a_Duration);
 	Pkt.WriteBool(false);  // Hide particles
 }
 
@@ -362,8 +362,8 @@ void cProtocol180::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x04);  // Entity Equipment packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteShort(a_SlotNum);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt16(a_SlotNum);
 	WriteItem(Pkt, a_Item);
 }
 
@@ -376,7 +376,7 @@ void cProtocol180::SendEntityHeadLook(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x19);  // Entity Head Look packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetHeadYaw());
 }
 
@@ -389,7 +389,7 @@ void cProtocol180::SendEntityLook(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x16);  // Entity Look packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteBool(a_Entity.IsOnGround());
@@ -404,9 +404,9 @@ void cProtocol180::SendEntityMetadata(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	WriteEntityMetadata(Pkt, a_Entity);
-	Pkt.WriteByte(0x7f);  // The termination byte
+	Pkt.WriteBEUInt8(0x7f);  // The termination byte
 }
 
 
@@ -418,7 +418,7 @@ void cProtocol180::SendEntityProperties(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x20);  // Entity Properties packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	WriteEntityProperties(Pkt, a_Entity);
 }
 
@@ -431,10 +431,10 @@ void cProtocol180::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x15);  // Entity Relative Move packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_RelX);
-	Pkt.WriteChar(a_RelY);
-	Pkt.WriteChar(a_RelZ);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_RelX);
+	Pkt.WriteBEInt8(a_RelY);
+	Pkt.WriteBEInt8(a_RelZ);
 	Pkt.WriteBool(a_Entity.IsOnGround());
 }
 
@@ -447,10 +447,10 @@ void cProtocol180::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, 
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x17);  // Entity Look And Relative Move packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_RelX);
-	Pkt.WriteChar(a_RelY);
-	Pkt.WriteChar(a_RelZ);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_RelX);
+	Pkt.WriteBEInt8(a_RelY);
+	Pkt.WriteBEInt8(a_RelZ);
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteBool(a_Entity.IsOnGround());
@@ -465,8 +465,8 @@ void cProtocol180::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1a);  // Entity Status packet
-	Pkt.WriteUInt32(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_Status);
+	Pkt.WriteBEUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_Status);
 }
 
 
@@ -478,11 +478,11 @@ void cProtocol180::SendEntityVelocity(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x12);  // Entity Velocity packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	// 400 = 8000 / 20 ... Conversion from our speed in m/s to 8000 m/tick
-	Pkt.WriteShort((short)(a_Entity.GetSpeedX() * 400));
-	Pkt.WriteShort((short)(a_Entity.GetSpeedY() * 400));
-	Pkt.WriteShort((short)(a_Entity.GetSpeedZ() * 400));
+	Pkt.WriteBEInt16((short)(a_Entity.GetSpeedX() * 400));
+	Pkt.WriteBEInt16((short)(a_Entity.GetSpeedY() * 400));
+	Pkt.WriteBEInt16((short)(a_Entity.GetSpeedZ() * 400));
 }
 
 
@@ -494,20 +494,20 @@ void cProtocol180::SendExplosion(double a_BlockX, double a_BlockY, double a_Bloc
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x27);  // Explosion packet
-	Pkt.WriteFloat((float)a_BlockX);
-	Pkt.WriteFloat((float)a_BlockY);
-	Pkt.WriteFloat((float)a_BlockZ);
-	Pkt.WriteFloat((float)a_Radius);
-	Pkt.WriteInt((int)a_BlocksAffected.size());
+	Pkt.WriteBEFloat(static_cast<float>(a_BlockX));
+	Pkt.WriteBEFloat(static_cast<float>(a_BlockY));
+	Pkt.WriteBEFloat(static_cast<float>(a_BlockZ));
+	Pkt.WriteBEFloat(static_cast<float>(a_Radius));
+	Pkt.WriteBEUInt32(static_cast<UInt32>(a_BlocksAffected.size()));
 	for (cVector3iArray::const_iterator itr = a_BlocksAffected.begin(), end = a_BlocksAffected.end(); itr != end; ++itr)
 	{
-		Pkt.WriteChar((char)itr->x);
-		Pkt.WriteChar((char)itr->y);
-		Pkt.WriteChar((char)itr->z);
+		Pkt.WriteBEInt8(static_cast<Int8>(itr->x));
+		Pkt.WriteBEInt8(static_cast<Int8>(itr->y));
+		Pkt.WriteBEInt8(static_cast<Int8>(itr->z));
 	}  // for itr - a_BlockAffected[]
-	Pkt.WriteFloat((float)a_PlayerMotion.x);
-	Pkt.WriteFloat((float)a_PlayerMotion.y);
-	Pkt.WriteFloat((float)a_PlayerMotion.z);
+	Pkt.WriteBEFloat(static_cast<float>(a_PlayerMotion.x));
+	Pkt.WriteBEFloat(static_cast<float>(a_PlayerMotion.y));
+	Pkt.WriteBEFloat(static_cast<float>(a_PlayerMotion.z));
 }
 
 
@@ -519,8 +519,8 @@ void cProtocol180::SendGameMode(eGameMode a_GameMode)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x2b);  // Change Game State packet
-	Pkt.WriteByte(3);  // Reason: Change game mode
-	Pkt.WriteFloat((float)a_GameMode);
+	Pkt.WriteBEUInt8(3);  // Reason: Change game mode
+	Pkt.WriteBEFloat(static_cast<float>(a_GameMode));  // The protocol really represents the value with a float!
 }
 
 
@@ -533,9 +533,9 @@ void cProtocol180::SendHealth(void)
 
 	cPacketizer Pkt(*this, 0x06);  // Update Health packet
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteFloat((float)Player->GetHealth());
-	Pkt.WriteVarInt((UInt32)Player->GetFoodLevel());
-	Pkt.WriteFloat((float)Player->GetFoodSaturationLevel());
+	Pkt.WriteBEFloat(static_cast<float>(Player->GetHealth()));
+	Pkt.WriteVarInt32((UInt32)Player->GetFoodLevel());
+	Pkt.WriteBEFloat(static_cast<float>(Player->GetFoodSaturationLevel()));
 }
 
 
@@ -547,8 +547,8 @@ void cProtocol180::SendInventorySlot(char a_WindowID, short a_SlotNum, const cIt
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x2f);  // Set Slot packet
-	Pkt.WriteChar(a_WindowID);
-	Pkt.WriteShort(a_SlotNum);
+	Pkt.WriteBEInt8(a_WindowID);
+	Pkt.WriteBEInt16(a_SlotNum);
 	WriteItem(Pkt, a_Item);
 }
 
@@ -566,7 +566,7 @@ void cProtocol180::SendKeepAlive(int a_PingID)
 	}
 	
 	cPacketizer Pkt(*this, 0x00);  // Keep Alive packet
-	Pkt.WriteVarInt(a_PingID);
+	Pkt.WriteVarInt32(a_PingID);
 }
 
 
@@ -579,11 +579,11 @@ void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 	{
 		cServer * Server = cRoot::Get()->GetServer();
 		cPacketizer Pkt(*this, 0x01);  // Join Game packet
-		Pkt.WriteUInt32(a_Player.GetUniqueID());
-		Pkt.WriteByte((Byte)a_Player.GetEffectiveGameMode() | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
-		Pkt.WriteChar((char)a_World.GetDimension());
-		Pkt.WriteByte(2);  // TODO: Difficulty (set to Normal)
-		Pkt.WriteByte(Server->GetMaxPlayers());
+		Pkt.WriteBEUInt32(a_Player.GetUniqueID());
+		Pkt.WriteBEUInt8((Byte)a_Player.GetEffectiveGameMode() | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
+		Pkt.WriteBEInt8((char)a_World.GetDimension());
+		Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
+		Pkt.WriteBEUInt8(Server->GetMaxPlayers());
 		Pkt.WriteString("default");  // Level type - wtf?
 		Pkt.WriteBool(false);  // Reduced Debug Info - wtf?
 	}
@@ -592,13 +592,13 @@ void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 	// Send the spawn position:
 	{
 		cPacketizer Pkt(*this, 0x05);  // Spawn Position packet
-		Pkt.WritePosition((int)a_World.GetSpawnX(), (int)a_World.GetSpawnY(), (int)a_World.GetSpawnZ());
+		Pkt.WritePosition64((int)a_World.GetSpawnX(), (int)a_World.GetSpawnY(), (int)a_World.GetSpawnZ());
 	}
 
 	// Send the server difficulty:
 	{
 		cPacketizer Pkt(*this, 0x41);
-		Pkt.WriteChar(1);
+		Pkt.WriteBEInt8(1);
 	}
 	
 	// Send player abilities:
@@ -615,7 +615,7 @@ void cProtocol180::SendLoginSuccess(void)
 	// Enable compression:
 	{
 		cPacketizer Pkt(*this, 0x03);  // Set compression packet
-		Pkt.WriteVarInt(256);
+		Pkt.WriteVarInt32(256);
 	}
 
 	m_State = 3;  // State = Game
@@ -639,10 +639,10 @@ void cProtocol180::SendPaintingSpawn(const cPainting & a_Painting)
 	double PosZ = a_Painting.GetPosZ();
 
 	cPacketizer Pkt(*this, 0x10);  // Spawn Painting packet
-	Pkt.WriteVarInt(a_Painting.GetUniqueID());
+	Pkt.WriteVarInt32(a_Painting.GetUniqueID());
 	Pkt.WriteString(a_Painting.GetName().c_str());
-	Pkt.WritePosition((int)PosX, (int)PosY, (int)PosZ);
-	Pkt.WriteChar(a_Painting.GetProtocolFacing());
+	Pkt.WritePosition64((int)PosX, (int)PosY, (int)PosZ);
+	Pkt.WriteBEInt8(a_Painting.GetProtocolFacing());
 }
 
 
@@ -654,19 +654,19 @@ void cProtocol180::SendMapColumn(int a_ID, int a_X, int a_Y, const Byte * a_Colo
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x34);
-	Pkt.WriteVarInt(a_ID);
-	Pkt.WriteByte(m_Scale);
+	Pkt.WriteVarInt32(a_ID);
+	Pkt.WriteBEUInt8(m_Scale);
 
-	Pkt.WriteVarInt(0);
-	Pkt.WriteByte(1);
-	Pkt.WriteByte(a_Length);
-	Pkt.WriteByte(a_X);
-	Pkt.WriteByte(a_Y);
+	Pkt.WriteVarInt32(0);
+	Pkt.WriteBEUInt8(1);
+	Pkt.WriteBEUInt8(a_Length);
+	Pkt.WriteBEUInt8(a_X);
+	Pkt.WriteBEUInt8(a_Y);
 
-	Pkt.WriteVarInt(a_Length);
+	Pkt.WriteVarInt32(a_Length);
 	for (unsigned int i = 0; i < a_Length; ++i)
 	{
-		Pkt.WriteByte(a_Colors[i]);
+		Pkt.WriteBEUInt8(a_Colors[i]);
 	}
 }
 
@@ -679,18 +679,18 @@ void cProtocol180::SendMapDecorators(int a_ID, const cMapDecoratorList & a_Decor
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x34);
-	Pkt.WriteVarInt(a_ID);
-	Pkt.WriteByte(m_Scale);
-	Pkt.WriteVarInt(a_Decorators.size());
+	Pkt.WriteVarInt32(a_ID);
+	Pkt.WriteBEUInt8(m_Scale);
+	Pkt.WriteVarInt32(a_Decorators.size());
 
 	for (cMapDecoratorList::const_iterator it = a_Decorators.begin(); it != a_Decorators.end(); ++it)
 	{
-		Pkt.WriteByte((it->GetType() << 4) | (it->GetRot() & 0xf));
-		Pkt.WriteByte(it->GetPixelX());
-		Pkt.WriteByte(it->GetPixelZ());
+		Pkt.WriteBEUInt8((it->GetType() << 4) | (it->GetRot() & 0xf));
+		Pkt.WriteBEUInt8(it->GetPixelX());
+		Pkt.WriteBEUInt8(it->GetPixelZ());
 	}
 
-	Pkt.WriteByte(0);
+	Pkt.WriteBEUInt8(0);
 }
 
 
@@ -715,22 +715,22 @@ void cProtocol180::SendPickupSpawn(const cPickup & a_Pickup)
 	
 	{
 		cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
-		Pkt.WriteVarInt(a_Pickup.GetUniqueID());
-		Pkt.WriteByte(2);  // Type = Pickup
+		Pkt.WriteVarInt32(a_Pickup.GetUniqueID());
+		Pkt.WriteBEUInt8(2);  // Type = Pickup
 		Pkt.WriteFPInt(a_Pickup.GetPosX());
 		Pkt.WriteFPInt(a_Pickup.GetPosY());
 		Pkt.WriteFPInt(a_Pickup.GetPosZ());
 		Pkt.WriteByteAngle(a_Pickup.GetYaw());
 		Pkt.WriteByteAngle(a_Pickup.GetPitch());
-		Pkt.WriteInt(0);  // No object data
+		Pkt.WriteBEInt32(0);  // No object data
 	}
 
 	{
 		cPacketizer Pkt(*this, 0x1c);  // Entity Metadata packet
-		Pkt.WriteVarInt(a_Pickup.GetUniqueID());
-		Pkt.WriteByte((0x05 << 5) | 10);  // Slot type + index 10
+		Pkt.WriteVarInt32(a_Pickup.GetUniqueID());
+		Pkt.WriteBEUInt8((0x05 << 5) | 10);  // Slot type + index 10
 		WriteItem(Pkt, a_Pickup.GetItem());
-		Pkt.WriteByte(0x7f);  // End of metadata
+		Pkt.WriteBEUInt8(0x7f);  // End of metadata
 	}
 }
 
@@ -758,9 +758,9 @@ void cProtocol180::SendPlayerAbilities(void)
 	{
 		Flags |= 0x04;
 	}
-	Pkt.WriteByte(Flags);
-	Pkt.WriteFloat((float)(0.05 * Player->GetFlyingMaxSpeed()));
-	Pkt.WriteFloat((float)(0.1 * Player->GetNormalMaxSpeed()));
+	Pkt.WriteBEUInt8(Flags);
+	Pkt.WriteBEFloat(static_cast<float>(0.05 * Player->GetFlyingMaxSpeed()));
+	Pkt.WriteBEFloat(static_cast<float>(0.1 * Player->GetNormalMaxSpeed()));
 }
 
 
@@ -772,8 +772,8 @@ void cProtocol180::SendEntityAnimation(const cEntity & a_Entity, char a_Animatio
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0b);  // Animation packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteChar(a_Animation);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEInt8(a_Animation);
 }
 
 
@@ -786,16 +786,16 @@ void cProtocol180::SendParticleEffect(const AString & a_ParticleName, float a_Sr
 	int ParticleID = GetParticleID(a_ParticleName);
 
 	cPacketizer Pkt(*this, 0x2A);
-	Pkt.WriteInt(ParticleID);
+	Pkt.WriteBEInt32(ParticleID);
 	Pkt.WriteBool(false);
-	Pkt.WriteFloat(a_SrcX);
-	Pkt.WriteFloat(a_SrcY);
-	Pkt.WriteFloat(a_SrcZ);
-	Pkt.WriteFloat(a_OffsetX);
-	Pkt.WriteFloat(a_OffsetY);
-	Pkt.WriteFloat(a_OffsetZ);
-	Pkt.WriteFloat(a_ParticleData);
-	Pkt.WriteInt(a_ParticleAmount);
+	Pkt.WriteBEFloat(a_SrcX);
+	Pkt.WriteBEFloat(a_SrcY);
+	Pkt.WriteBEFloat(a_SrcZ);
+	Pkt.WriteBEFloat(a_OffsetX);
+	Pkt.WriteBEFloat(a_OffsetY);
+	Pkt.WriteBEFloat(a_OffsetZ);
+	Pkt.WriteBEFloat(a_ParticleData);
+	Pkt.WriteBEInt32(a_ParticleAmount);
 }
 
 
@@ -807,13 +807,13 @@ void cProtocol180::SendPlayerListAddPlayer(const cPlayer & a_Player)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
-	Pkt.WriteVarInt(0);
-	Pkt.WriteVarInt(1);
+	Pkt.WriteVarInt32(0);
+	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
 	Pkt.WriteString(a_Player.GetPlayerListName());
 
 	const Json::Value & Properties = a_Player.GetClientHandle()->GetProperties();
-	Pkt.WriteVarInt(Properties.size());
+	Pkt.WriteVarInt32(Properties.size());
 	for (Json::Value::iterator itr = Properties.begin(), end = Properties.end(); itr != end; ++itr)
 	{
 		Pkt.WriteString(((Json::Value)*itr).get("name", "").asString());
@@ -830,8 +830,8 @@ void cProtocol180::SendPlayerListAddPlayer(const cPlayer & a_Player)
 		}
 	}
 
-	Pkt.WriteVarInt((UInt32)a_Player.GetGameMode());
-	Pkt.WriteVarInt((UInt32)a_Player.GetClientHandle()->GetPing());
+	Pkt.WriteVarInt32((UInt32)a_Player.GetGameMode());
+	Pkt.WriteVarInt32((UInt32)a_Player.GetClientHandle()->GetPing());
 	Pkt.WriteBool(false);
 }
 
@@ -844,8 +844,8 @@ void cProtocol180::SendPlayerListRemovePlayer(const cPlayer & a_Player)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
-	Pkt.WriteVarInt(4);
-	Pkt.WriteVarInt(1);
+	Pkt.WriteVarInt32(4);
+	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
 }
 
@@ -858,10 +858,10 @@ void cProtocol180::SendPlayerListUpdateGameMode(const cPlayer & a_Player)
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
-	Pkt.WriteVarInt(1);
-	Pkt.WriteVarInt(1);
+	Pkt.WriteVarInt32(1);
+	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
-	Pkt.WriteVarInt((UInt32)a_Player.GetGameMode());
+	Pkt.WriteVarInt32((UInt32)a_Player.GetGameMode());
 }
 
 
@@ -876,10 +876,10 @@ void cProtocol180::SendPlayerListUpdatePing(const cPlayer & a_Player)
 	if (ClientHandle != nullptr)
 	{
 		cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
-		Pkt.WriteVarInt(2);
-		Pkt.WriteVarInt(1);
+		Pkt.WriteVarInt32(2);
+		Pkt.WriteVarInt32(1);
 		Pkt.WriteUUID(a_Player.GetUUID());
-		Pkt.WriteVarInt(static_cast<UInt32>(ClientHandle->GetPing()));
+		Pkt.WriteVarInt32(static_cast<UInt32>(ClientHandle->GetPing()));
 	}
 }
 
@@ -892,8 +892,8 @@ void cProtocol180::SendPlayerListUpdateDisplayName(const cPlayer & a_Player, con
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, 0x38);  // Playerlist Item packet
-	Pkt.WriteVarInt(3);
-	Pkt.WriteVarInt(1);
+	Pkt.WriteVarInt32(3);
+	Pkt.WriteVarInt32(1);
 	Pkt.WriteUUID(a_Player.GetUUID());
 
 	if (a_CustomName.empty())
@@ -917,22 +917,22 @@ void cProtocol180::SendPlayerMaxSpeed(void)
 	
 	cPacketizer Pkt(*this, 0x20);  // Entity Properties
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteVarInt(Player->GetUniqueID());
-	Pkt.WriteInt(1);  // Count
+	Pkt.WriteVarInt32(Player->GetUniqueID());
+	Pkt.WriteBEInt32(1);  // Count
 	Pkt.WriteString("generic.movementSpeed");
 	// The default game speed is 0.1, multiply that value by the relative speed:
-	Pkt.WriteDouble(0.1 * Player->GetNormalMaxSpeed());
+	Pkt.WriteBEDouble(0.1 * Player->GetNormalMaxSpeed());
 	if (Player->IsSprinting())
 	{
-		Pkt.WriteVarInt(1);  // Modifier count
-		Pkt.WriteInt64(0x662a6b8dda3e4c1c);
-		Pkt.WriteInt64(0x881396ea6097278d);  // UUID of the modifier
-		Pkt.WriteDouble(Player->GetSprintingMaxSpeed() - Player->GetNormalMaxSpeed());
-		Pkt.WriteByte(2);
+		Pkt.WriteVarInt32(1);  // Modifier count
+		Pkt.WriteBEUInt64(0x662a6b8dda3e4c1c);
+		Pkt.WriteBEUInt64(0x881396ea6097278d);  // UUID of the modifier
+		Pkt.WriteBEDouble(Player->GetSprintingMaxSpeed() - Player->GetNormalMaxSpeed());
+		Pkt.WriteBEUInt8(2);
 	}
 	else
 	{
-		Pkt.WriteVarInt(0);  // Modifier count
+		Pkt.WriteVarInt32(0);  // Modifier count
 	}
 }
 
@@ -946,15 +946,15 @@ void cProtocol180::SendPlayerMoveLook(void)
 	
 	cPacketizer Pkt(*this, 0x08);  // Player Position And Look packet
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteDouble(Player->GetPosX());
+	Pkt.WriteBEDouble(Player->GetPosX());
 	
 	// The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
-	Pkt.WriteDouble(Player->GetPosY() + 0.001);
+	Pkt.WriteBEDouble(Player->GetPosY() + 0.001);
 	
-	Pkt.WriteDouble(Player->GetPosZ());
-	Pkt.WriteFloat((float)Player->GetYaw());
-	Pkt.WriteFloat((float)Player->GetPitch());
-	Pkt.WriteByte(0);
+	Pkt.WriteBEDouble(Player->GetPosZ());
+	Pkt.WriteBEFloat(static_cast<float>(Player->GetYaw()));
+	Pkt.WriteBEFloat(static_cast<float>(Player->GetPitch()));
+	Pkt.WriteBEUInt8(0);
 }
 
 
@@ -975,7 +975,7 @@ void cProtocol180::SendPlayerSpawn(const cPlayer & a_Player)
 {
 	// Called to spawn another player for the client
 	cPacketizer Pkt(*this, 0x0c);  // Spawn Player packet
-	Pkt.WriteVarInt(a_Player.GetUniqueID());
+	Pkt.WriteVarInt32(a_Player.GetUniqueID());
 	Pkt.WriteUUID(cMojangAPI::MakeUUIDShort(a_Player.GetUUID()));
 	Pkt.WriteFPInt(a_Player.GetPosX());
 	Pkt.WriteFPInt(a_Player.GetPosY() + 0.001);  // The "+ 0.001" is there because otherwise the player falls through the block they were standing on.
@@ -983,12 +983,12 @@ void cProtocol180::SendPlayerSpawn(const cPlayer & a_Player)
 	Pkt.WriteByteAngle(a_Player.GetYaw());
 	Pkt.WriteByteAngle(a_Player.GetPitch());
 	short ItemType = a_Player.GetEquippedItem().IsEmpty() ? 0 : a_Player.GetEquippedItem().m_ItemType;
-	Pkt.WriteShort(ItemType);
-	Pkt.WriteByte((3 << 5) | 6);  // Metadata: float + index 6
-	Pkt.WriteFloat((float)a_Player.GetHealth());
-	Pkt.WriteByte((4 << 5 | (2 & 0x1F)) & 0xFF);
+	Pkt.WriteBEInt16(ItemType);
+	Pkt.WriteBEUInt8((3 << 5) | 6);  // Metadata: float + index 6
+	Pkt.WriteBEFloat(static_cast<float>(a_Player.GetHealth()));
+	Pkt.WriteBEUInt8((4 << 5 | (2 & 0x1F)) & 0xFF);
 	Pkt.WriteString(a_Player.GetName());
-	Pkt.WriteByte(0x7f);  // Metadata: end
+	Pkt.WriteBEUInt8(0x7f);  // Metadata: end
 }
 
 
@@ -1013,8 +1013,8 @@ void cProtocol180::SendRemoveEntityEffect(const cEntity & a_Entity, int a_Effect
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1e);
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteByte(a_EffectID);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt8(a_EffectID);
 }
 
 
@@ -1031,9 +1031,9 @@ void cProtocol180::SendRespawn(eDimension a_Dimension, bool a_ShouldIgnoreDimens
 
 	cPacketizer Pkt(*this, 0x07);  // Respawn packet
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteInt((int)a_Dimension);
-	Pkt.WriteByte(2);  // TODO: Difficulty (set to Normal)
-	Pkt.WriteByte((Byte)Player->GetEffectiveGameMode());
+	Pkt.WriteBEInt32((int)a_Dimension);
+	Pkt.WriteBEUInt8(2);  // TODO: Difficulty (set to Normal)
+	Pkt.WriteBEUInt8((Byte)Player->GetEffectiveGameMode());
 	Pkt.WriteString("default");
 	m_LastSentDimension = a_Dimension;
 }
@@ -1048,9 +1048,9 @@ void cProtocol180::SendExperience(void)
 	
 	cPacketizer Pkt(*this, 0x1f);  // Experience Packet
 	cPlayer * Player = m_Client->GetPlayer();
-	Pkt.WriteFloat(Player->GetXpPercentage());
-	Pkt.WriteVarInt((UInt32)Player->GetXpLevel());
-	Pkt.WriteVarInt((UInt32)Player->GetCurrentXp());
+	Pkt.WriteBEFloat(Player->GetXpPercentage());
+	Pkt.WriteVarInt32((UInt32)Player->GetXpLevel());
+	Pkt.WriteVarInt32((UInt32)Player->GetCurrentXp());
 }
 
 
@@ -1062,11 +1062,11 @@ void cProtocol180::SendExperienceOrb(const cExpOrb & a_ExpOrb)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x11);
-	Pkt.WriteVarInt(a_ExpOrb.GetUniqueID());
+	Pkt.WriteVarInt32(a_ExpOrb.GetUniqueID());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosX());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosY());
 	Pkt.WriteFPInt(a_ExpOrb.GetPosZ());
-	Pkt.WriteShort(a_ExpOrb.GetReward());
+	Pkt.WriteBEInt16(a_ExpOrb.GetReward());
 }
 
 
@@ -1079,7 +1079,7 @@ void cProtocol180::SendScoreboardObjective(const AString & a_Name, const AString
 	
 	cPacketizer Pkt(*this, 0x3b);
 	Pkt.WriteString(a_Name);
-	Pkt.WriteByte(a_Mode);
+	Pkt.WriteBEUInt8(a_Mode);
 	if ((a_Mode == 0) || (a_Mode == 2))
 	{
 		Pkt.WriteString(a_DisplayName);
@@ -1097,12 +1097,12 @@ void cProtocol180::SendScoreUpdate(const AString & a_Objective, const AString & 
 	
 	cPacketizer Pkt(*this, 0x3c);
 	Pkt.WriteString(a_Player);
-	Pkt.WriteByte(a_Mode);
+	Pkt.WriteBEUInt8(a_Mode);
 	Pkt.WriteString(a_Objective);
 
 	if (a_Mode != 1)
 	{
-		Pkt.WriteVarInt((UInt32) a_Score);
+		Pkt.WriteVarInt32((UInt32) a_Score);
 	}
 }
 
@@ -1115,7 +1115,7 @@ void cProtocol180::SendDisplayObjective(const AString & a_Objective, cScoreboard
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x3d);
-	Pkt.WriteByte((int) a_Display);
+	Pkt.WriteBEUInt8((int) a_Display);
 	Pkt.WriteString(a_Objective);
 }
 
@@ -1129,11 +1129,11 @@ void cProtocol180::SendSoundEffect(const AString & a_SoundName, double a_X, doub
 
 	cPacketizer Pkt(*this, 0x29);  // Sound Effect packet
 	Pkt.WriteString(a_SoundName);
-	Pkt.WriteInt((int)(a_X * 8.0));
-	Pkt.WriteInt((int)(a_Y * 8.0));
-	Pkt.WriteInt((int)(a_Z * 8.0));
-	Pkt.WriteFloat(a_Volume);
-	Pkt.WriteByte((Byte)(a_Pitch * 63));
+	Pkt.WriteBEInt32((int)(a_X * 8.0));
+	Pkt.WriteBEInt32((int)(a_Y * 8.0));
+	Pkt.WriteBEInt32((int)(a_Z * 8.0));
+	Pkt.WriteBEFloat(a_Volume);
+	Pkt.WriteBEUInt8((Byte)(a_Pitch * 63));
 }
 
 
@@ -1145,9 +1145,9 @@ void cProtocol180::SendSoundParticleEffect(int a_EffectID, int a_SrcX, int a_Src
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x28);  // Effect packet
-	Pkt.WriteInt(a_EffectID);
-	Pkt.WritePosition(a_SrcX, a_SrcY, a_SrcZ);
-	Pkt.WriteInt(a_Data);
+	Pkt.WriteBEInt32(a_EffectID);
+	Pkt.WritePosition64(a_SrcX, a_SrcY, a_SrcZ);
+	Pkt.WriteBEInt32(a_Data);
 	Pkt.WriteBool(false);
 }
 
@@ -1160,17 +1160,17 @@ void cProtocol180::SendSpawnFallingBlock(const cFallingBlock & a_FallingBlock)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0e);  // Spawn Object packet
-	Pkt.WriteVarInt(a_FallingBlock.GetUniqueID());
-	Pkt.WriteByte(70);  // Falling block
+	Pkt.WriteVarInt32(a_FallingBlock.GetUniqueID());
+	Pkt.WriteBEUInt8(70);  // Falling block
 	Pkt.WriteFPInt(a_FallingBlock.GetPosX());
 	Pkt.WriteFPInt(a_FallingBlock.GetPosY());
 	Pkt.WriteFPInt(a_FallingBlock.GetPosZ());
 	Pkt.WriteByteAngle(a_FallingBlock.GetYaw());
 	Pkt.WriteByteAngle(a_FallingBlock.GetPitch());
-	Pkt.WriteInt(((int)a_FallingBlock.GetBlockType()) | (((int)a_FallingBlock.GetBlockMeta()) << 12));
-	Pkt.WriteShort((short)(a_FallingBlock.GetSpeedX() * 400));
-	Pkt.WriteShort((short)(a_FallingBlock.GetSpeedY() * 400));
-	Pkt.WriteShort((short)(a_FallingBlock.GetSpeedZ() * 400));
+	Pkt.WriteBEInt32(((int)a_FallingBlock.GetBlockType()) | (((int)a_FallingBlock.GetBlockMeta()) << 12));
+	Pkt.WriteBEInt16((short)(a_FallingBlock.GetSpeedX() * 400));
+	Pkt.WriteBEInt16((short)(a_FallingBlock.GetSpeedY() * 400));
+	Pkt.WriteBEInt16((short)(a_FallingBlock.GetSpeedZ() * 400));
 }
 
 
@@ -1182,19 +1182,19 @@ void cProtocol180::SendSpawnMob(const cMonster & a_Mob)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0f);  // Spawn Mob packet
-	Pkt.WriteVarInt(a_Mob.GetUniqueID());
-	Pkt.WriteByte((Byte)a_Mob.GetMobType());
+	Pkt.WriteVarInt32(a_Mob.GetUniqueID());
+	Pkt.WriteBEUInt8((Byte)a_Mob.GetMobType());
 	Pkt.WriteFPInt(a_Mob.GetPosX());
 	Pkt.WriteFPInt(a_Mob.GetPosY());
 	Pkt.WriteFPInt(a_Mob.GetPosZ());
 	Pkt.WriteByteAngle(a_Mob.GetPitch());
 	Pkt.WriteByteAngle(a_Mob.GetHeadYaw());
 	Pkt.WriteByteAngle(a_Mob.GetYaw());
-	Pkt.WriteShort((short)(a_Mob.GetSpeedX() * 400));
-	Pkt.WriteShort((short)(a_Mob.GetSpeedY() * 400));
-	Pkt.WriteShort((short)(a_Mob.GetSpeedZ() * 400));
+	Pkt.WriteBEInt16((short)(a_Mob.GetSpeedX() * 400));
+	Pkt.WriteBEInt16((short)(a_Mob.GetSpeedY() * 400));
+	Pkt.WriteBEInt16((short)(a_Mob.GetSpeedZ() * 400));
 	WriteEntityMetadata(Pkt, a_Mob);
-	Pkt.WriteByte(0x7f);  // Metadata terminator
+	Pkt.WriteBEUInt8(0x7f);  // Metadata terminator
 }
 
 
@@ -1213,19 +1213,19 @@ void cProtocol180::SendSpawnObject(const cEntity & a_Entity, char a_ObjectType, 
 	}
 
 	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteByte(a_ObjectType);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WriteBEUInt8(a_ObjectType);
 	Pkt.WriteFPInt(PosX);
 	Pkt.WriteFPInt(a_Entity.GetPosY());
 	Pkt.WriteFPInt(PosZ);
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteByteAngle(Yaw);
-	Pkt.WriteInt(a_ObjectData);
+	Pkt.WriteBEInt32(a_ObjectData);
 	if (a_ObjectData != 0)
 	{
-		Pkt.WriteShort((short)(a_Entity.GetSpeedX() * 400));
-		Pkt.WriteShort((short)(a_Entity.GetSpeedY() * 400));
-		Pkt.WriteShort((short)(a_Entity.GetSpeedZ() * 400));
+		Pkt.WriteBEInt16((short)(a_Entity.GetSpeedX() * 400));
+		Pkt.WriteBEInt16((short)(a_Entity.GetSpeedY() * 400));
+		Pkt.WriteBEInt16((short)(a_Entity.GetSpeedZ() * 400));
 	}
 }
 
@@ -1238,19 +1238,19 @@ void cProtocol180::SendSpawnVehicle(const cEntity & a_Vehicle, char a_VehicleTyp
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0xe);  // Spawn Object packet
-	Pkt.WriteVarInt(a_Vehicle.GetUniqueID());
-	Pkt.WriteByte(a_VehicleType);
+	Pkt.WriteVarInt32(a_Vehicle.GetUniqueID());
+	Pkt.WriteBEUInt8(a_VehicleType);
 	Pkt.WriteFPInt(a_Vehicle.GetPosX());
 	Pkt.WriteFPInt(a_Vehicle.GetPosY());
 	Pkt.WriteFPInt(a_Vehicle.GetPosZ());
 	Pkt.WriteByteAngle(a_Vehicle.GetPitch());
 	Pkt.WriteByteAngle(a_Vehicle.GetYaw());
-	Pkt.WriteInt(a_VehicleSubType);
+	Pkt.WriteBEInt32(a_VehicleSubType);
 	if (a_VehicleSubType != 0)
 	{
-		Pkt.WriteShort((short)(a_Vehicle.GetSpeedX() * 400));
-		Pkt.WriteShort((short)(a_Vehicle.GetSpeedY() * 400));
-		Pkt.WriteShort((short)(a_Vehicle.GetSpeedZ() * 400));
+		Pkt.WriteBEInt16((short)(a_Vehicle.GetSpeedX() * 400));
+		Pkt.WriteBEInt16((short)(a_Vehicle.GetSpeedY() * 400));
+		Pkt.WriteBEInt16((short)(a_Vehicle.GetSpeedZ() * 400));
 	}
 }
 
@@ -1263,7 +1263,7 @@ void cProtocol180::SendStatistics(const cStatManager & a_Manager)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x37);
-	Pkt.WriteVarInt(statCount);  // TODO 2014-05-11 xdot: Optimization: Send "dirty" statistics only
+	Pkt.WriteVarInt32(statCount);  // TODO 2014-05-11 xdot: Optimization: Send "dirty" statistics only
 
 	for (size_t i = 0; i < (size_t)statCount; ++i)
 	{
@@ -1271,7 +1271,7 @@ void cProtocol180::SendStatistics(const cStatManager & a_Manager)
 		const AString & StatName = cStatInfo::GetName((eStatistic) i);
 
 		Pkt.WriteString(StatName);
-		Pkt.WriteVarInt(Value);
+		Pkt.WriteVarInt32(Value);
 	}
 }
 
@@ -1284,7 +1284,7 @@ void cProtocol180::SendTabCompletionResults(const AStringVector & a_Results)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x3a);  // Tab-Complete packet
-	Pkt.WriteVarInt((int)a_Results.size());
+	Pkt.WriteVarInt32((int)a_Results.size());
 
 	for (AStringVector::const_iterator itr = a_Results.begin(), end = a_Results.end(); itr != end; ++itr)
 	{
@@ -1301,7 +1301,7 @@ void cProtocol180::SendTeleportEntity(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x18);
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
 	Pkt.WriteFPInt(a_Entity.GetPosX());
 	Pkt.WriteFPInt(a_Entity.GetPosY());
 	Pkt.WriteFPInt(a_Entity.GetPosZ());
@@ -1319,8 +1319,8 @@ void cProtocol180::SendThunderbolt(int a_BlockX, int a_BlockY, int a_BlockZ)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x2c);  // Spawn Global Entity packet
-	Pkt.WriteVarInt(0);  // EntityID = 0, always
-	Pkt.WriteByte(1);  // Type = Thunderbolt
+	Pkt.WriteVarInt32(0);  // EntityID = 0, always
+	Pkt.WriteBEUInt8(1);  // Type = Thunderbolt
 	Pkt.WriteFPInt(a_BlockX);
 	Pkt.WriteFPInt(a_BlockY);
 	Pkt.WriteFPInt(a_BlockZ);
@@ -1340,8 +1340,8 @@ void cProtocol180::SendTimeUpdate(Int64 a_WorldAge, Int64 a_TimeOfDay, bool a_Do
 	}
 	
 	cPacketizer Pkt(*this, 0x03);
-	Pkt.WriteInt64(a_WorldAge);
-	Pkt.WriteInt64(a_TimeOfDay);
+	Pkt.WriteBEInt64(a_WorldAge);
+	Pkt.WriteBEInt64(a_TimeOfDay);
 }
 
 
@@ -1353,11 +1353,11 @@ void cProtocol180::SendUnloadChunk(int a_ChunkX, int a_ChunkZ)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x21);  // Chunk Data packet
-	Pkt.WriteInt(a_ChunkX);
-	Pkt.WriteInt(a_ChunkZ);
+	Pkt.WriteBEInt32(a_ChunkX);
+	Pkt.WriteBEInt32(a_ChunkZ);
 	Pkt.WriteBool(true);
-	Pkt.WriteShort(0);  // Primary bitmap
-	Pkt.WriteVarInt(0);  // Data size
+	Pkt.WriteBEInt16(0);  // Primary bitmap
+	Pkt.WriteVarInt32(0);  // Data size
 }
 
 
@@ -1368,7 +1368,7 @@ void cProtocol180::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x35);  // Update tile entity packet
-	Pkt.WritePosition(a_BlockEntity.GetPosX(), a_BlockEntity.GetPosY(), a_BlockEntity.GetPosZ());
+	Pkt.WritePosition64(a_BlockEntity.GetPosX(), a_BlockEntity.GetPosY(), a_BlockEntity.GetPosZ());
 
 	Byte Action = 0;
 	switch (a_BlockEntity.GetBlockType())
@@ -1380,7 +1380,7 @@ void cProtocol180::SendUpdateBlockEntity(cBlockEntity & a_BlockEntity)
 		case E_BLOCK_FLOWER_POT:    Action = 5; break;  // Update flower pot
 		default: ASSERT(!"Unhandled or unimplemented BlockEntity update request!"); break;
 	}
-	Pkt.WriteByte(Action);
+	Pkt.WriteBEUInt8(Action);
 
 	WriteBlockEntity(Pkt, a_BlockEntity);
 }
@@ -1394,7 +1394,7 @@ void cProtocol180::SendUpdateSign(int a_BlockX, int a_BlockY, int a_BlockZ, cons
 	ASSERT(m_State == 3);  // In game mode?
 
 	cPacketizer Pkt(*this, 0x33);
-	Pkt.WritePosition(a_BlockX, a_BlockY, a_BlockZ);
+	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 
 	Json::StyledWriter JsonWriter;
 	AString Lines[] = { a_Line1, a_Line2, a_Line3, a_Line4 };
@@ -1415,8 +1415,8 @@ void cProtocol180::SendUseBed(const cEntity & a_Entity, int a_BlockX, int a_Bloc
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x0a);
-	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WritePosition(a_BlockX, a_BlockY, a_BlockZ);
+	Pkt.WriteVarInt32(a_Entity.GetUniqueID());
+	Pkt.WritePosition64(a_BlockX, a_BlockY, a_BlockZ);
 }
 
 
@@ -1429,8 +1429,8 @@ void cProtocol180::SendWeather(eWeather a_Weather)
 	
 	{
 		cPacketizer Pkt(*this, 0x2b);  // Change Game State packet
-		Pkt.WriteByte((a_Weather == wSunny) ? 1 : 2);  // End rain / begin rain
-		Pkt.WriteFloat(0);  // Unused for weather
+		Pkt.WriteBEUInt8((a_Weather == wSunny) ? 1 : 2);  // End rain / begin rain
+		Pkt.WriteBEFloat(0);  // Unused for weather
 	}
 
 	// TODO: Fade effect, somehow
@@ -1445,8 +1445,8 @@ void cProtocol180::SendWholeInventory(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x30);  // Window Items packet
-	Pkt.WriteChar(a_Window.GetWindowID());
-	Pkt.WriteShort(a_Window.GetNumSlots());
+	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEInt16(a_Window.GetNumSlots());
 	cItems Slots;
 	a_Window.GetSlots(*(m_Client->GetPlayer()), Slots);
 	for (cItems::const_iterator itr = Slots.begin(), end = Slots.end(); itr != end; ++itr)
@@ -1464,7 +1464,7 @@ void cProtocol180::SendWindowClose(const cWindow & a_Window)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x2e);
-	Pkt.WriteChar(a_Window.GetWindowID());
+	Pkt.WriteBEInt8(a_Window.GetWindowID());
 }
 
 
@@ -1482,7 +1482,7 @@ void cProtocol180::SendWindowOpen(const cWindow & a_Window)
 	}
 
 	cPacketizer Pkt(*this, 0x2d);
-	Pkt.WriteChar(a_Window.GetWindowID());
+	Pkt.WriteBEInt8(a_Window.GetWindowID());
 	Pkt.WriteString(a_Window.GetWindowTypeName());
 	Pkt.WriteString(Printf("{\"text\":\"%s\"}", a_Window.GetWindowTitle().c_str()));
 
@@ -1492,19 +1492,19 @@ void cProtocol180::SendWindowOpen(const cWindow & a_Window)
 		case cWindow::wtEnchantment:
 		case cWindow::wtAnvil:
 		{
-			Pkt.WriteChar(0);
+			Pkt.WriteBEInt8(0);
 			break;
 		}
 		default:
 		{
-			Pkt.WriteChar(a_Window.GetNumNonInventorySlots());
+			Pkt.WriteBEInt8(a_Window.GetNumNonInventorySlots());
 			break;
 		}
 	}
 
 	if (a_Window.GetWindowType() == cWindow::wtAnimalChest)
 	{
-		Pkt.WriteInt(0);  // TODO: The animal's EntityID
+		Pkt.WriteBEInt32(0);  // TODO: The animal's EntityID
 	}
 }
 
@@ -1517,9 +1517,9 @@ void cProtocol180::SendWindowProperty(const cWindow & a_Window, short a_Property
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x31);  // Window Property packet
-	Pkt.WriteChar(a_Window.GetWindowID());
-	Pkt.WriteShort(a_Property);
-	Pkt.WriteShort(a_Value);
+	Pkt.WriteBEInt8(a_Window.GetWindowID());
+	Pkt.WriteBEInt16(a_Property);
+	Pkt.WriteBEInt16(a_Value);
 }
 
 
@@ -1538,7 +1538,10 @@ bool cProtocol180::CompressPacket(const AString & a_Packet, AString & a_Compress
 		return false;
 	}
 
-	int Status = compress2((Bytef*)CompressedData, &CompressedSize, (const Bytef*)a_Packet.data(), a_Packet.size(), Z_DEFAULT_COMPRESSION);
+	int Status = compress2(
+		reinterpret_cast<Bytef *>(CompressedData), &CompressedSize,
+		reinterpret_cast<const Bytef *>(a_Packet.data()), a_Packet.size(), Z_DEFAULT_COMPRESSION
+	);
 	if (Status != Z_OK)
 	{
 		return false;
@@ -1546,12 +1549,12 @@ bool cProtocol180::CompressPacket(const AString & a_Packet, AString & a_Compress
 
 	AString LengthData;
 	cByteBuffer Buffer(20);
-	Buffer.WriteVarInt((UInt32)a_Packet.size());
+	Buffer.WriteVarInt32(static_cast<UInt32>(a_Packet.size()));
 	Buffer.ReadAll(LengthData);
 	Buffer.CommitRead();
 
-	Buffer.WriteVarInt(CompressedSize + LengthData.size());
-	Buffer.WriteVarInt(a_Packet.size());
+	Buffer.WriteVarInt32(CompressedSize + LengthData.size());
+	Buffer.WriteVarInt32(static_cast<UInt32>(a_Packet.size()));
 	Buffer.ReadAll(LengthData);
 	Buffer.CommitRead();
 
@@ -1949,7 +1952,7 @@ void cProtocol180::HandlePacketStatusPing(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEInt64, Int64, Timestamp);
 
 	cPacketizer Pkt(*this, 0x01);  // Ping packet
-	Pkt.WriteInt64(Timestamp);
+	Pkt.WriteBEInt64(Timestamp);
 }
 
 
@@ -2086,10 +2089,10 @@ void cProtocol180::HandlePacketLoginStart(cByteBuffer & a_ByteBuffer)
 		cPacketizer Pkt(*this, 0x01);
 		Pkt.WriteString(Server->GetServerID());
 		const AString & PubKeyDer = Server->GetPublicKeyDER();
-		Pkt.WriteVarInt((short)PubKeyDer.size());
+		Pkt.WriteVarInt32((short)PubKeyDer.size());
 		Pkt.WriteBuf(PubKeyDer.data(), PubKeyDer.size());
-		Pkt.WriteVarInt(4);
-		Pkt.WriteInt((int)(intptr_t)this);  // Using 'this' as the cryptographic nonce, so that we don't have to generate one each time :)
+		Pkt.WriteVarInt32(4);
+		Pkt.WriteBEInt32((int)(intptr_t)this);  // Using 'this' as the cryptographic nonce, so that we don't have to generate one each time :)
 		m_Client->SetUsername(Username);
 		return;
 	}
@@ -2115,7 +2118,7 @@ void cProtocol180::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 	HANDLE_READ(a_ByteBuffer, ReadBEUInt8, UInt8, Status);
 
 	int BlockX, BlockY, BlockZ;
-	if (!a_ByteBuffer.ReadPosition(BlockX, BlockY, BlockZ))
+	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
 	{
 		return;
 	}
@@ -2131,7 +2134,7 @@ void cProtocol180::HandlePacketBlockDig(cByteBuffer & a_ByteBuffer)
 void cProtocol180::HandlePacketBlockPlace(cByteBuffer & a_ByteBuffer)
 {
 	int BlockX, BlockY, BlockZ;
-	if (!a_ByteBuffer.ReadPosition(BlockX, BlockY, BlockZ))
+	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
 	{
 		return;
 	}
@@ -2410,7 +2413,7 @@ void cProtocol180::HandlePacketTabComplete(cByteBuffer & a_ByteBuffer)
 void cProtocol180::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 {
 	int BlockX, BlockY, BlockZ;
-	if (!a_ByteBuffer.ReadPosition(BlockX, BlockY, BlockZ))
+	if (!a_ByteBuffer.ReadPosition64(BlockX, BlockY, BlockZ))
 	{
 		return;
 	}
@@ -2799,8 +2802,8 @@ void cProtocol180::SendPacket(cPacketizer & a_Pkt)
 	else if (m_State == 3)
 	{
 		// The packet is not compressed, indicate this in the packet header:
-		m_OutPacketLenBuffer.WriteVarInt(PacketLen + 1);
-		m_OutPacketLenBuffer.WriteVarInt(0);
+		m_OutPacketLenBuffer.WriteVarInt32(PacketLen + 1);
+		m_OutPacketLenBuffer.WriteVarInt32(0);
 		AString LengthData;
 		m_OutPacketLenBuffer.ReadAll(LengthData);
 		SendData(LengthData.data(), LengthData.size());
@@ -2808,7 +2811,7 @@ void cProtocol180::SendPacket(cPacketizer & a_Pkt)
 	else
 	{
 		// Compression doesn't apply to this state, send raw data:
-		m_OutPacketLenBuffer.WriteVarInt(PacketLen);
+		m_OutPacketLenBuffer.WriteVarInt32(PacketLen);
 		AString LengthData;
 		m_OutPacketLenBuffer.ReadAll(LengthData);
 		SendData(LengthData.data(), LengthData.size());
@@ -2853,17 +2856,17 @@ void cProtocol180::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 	
 	if (a_Item.IsEmpty())
 	{
-		a_Pkt.WriteShort(-1);
+		a_Pkt.WriteBEInt16(-1);
 		return;
 	}
 	
-	a_Pkt.WriteShort(ItemType);
-	a_Pkt.WriteByte (a_Item.m_ItemCount);
-	a_Pkt.WriteShort(a_Item.m_ItemDamage);
+	a_Pkt.WriteBEInt16(ItemType);
+	a_Pkt.WriteBEInt8(a_Item.m_ItemCount);
+	a_Pkt.WriteBEInt16(a_Item.m_ItemDamage);
 	
 	if (a_Item.m_Enchantments.IsEmpty() && a_Item.IsBothNameAndLoreEmpty() && (a_Item.m_ItemType != E_ITEM_FIREWORK_ROCKET) && (a_Item.m_ItemType != E_ITEM_FIREWORK_STAR))
 	{
-		a_Pkt.WriteChar(0);
+		a_Pkt.WriteBEInt8(0);
 		return;
 	}
 
@@ -2913,7 +2916,7 @@ void cProtocol180::WriteItem(cPacketizer & a_Pkt, const cItem & a_Item)
 	AString Result = Writer.GetResult();
 	if (Result.size() == 0)
 	{
-		a_Pkt.WriteChar(0);
+		a_Pkt.WriteBEInt8(0);
 		return;
 	}
 	a_Pkt.WriteBuf(Result.data(), Result.size());
@@ -3038,21 +3041,21 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 	{
 		Flags |= 0x20;
 	}
-	a_Pkt.WriteByte(0);  // Byte(0) + index 0
-	a_Pkt.WriteByte(Flags);
+	a_Pkt.WriteBEUInt8(0);  // Byte(0) + index 0
+	a_Pkt.WriteBEUInt8(Flags);
 	
 	switch (a_Entity.GetEntityType())
 	{
 		case cEntity::etPlayer: break;  // TODO?
 		case cEntity::etPickup:
 		{
-			a_Pkt.WriteByte((5 << 5) | 10);  // Slot(5) + index 10
+			a_Pkt.WriteBEUInt8((5 << 5) | 10);  // Slot(5) + index 10
 			WriteItem(a_Pkt, reinterpret_cast<const cPickup &>(a_Entity).GetItem());
 			break;
 		}
 		case cEntity::etMinecart:
 		{
-			a_Pkt.WriteByte(0x51);
+			a_Pkt.WriteBEUInt8(0x51);
 
 			// The following expression makes Minecarts shake more with less health or higher damage taken
 			// It gets half the maximum health, and takes it away from the current health minus the half health:
@@ -3062,11 +3065,11 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 			Health: 1 | 3 - (1 - 3) = 5
 			*/
 			auto & Minecart = reinterpret_cast<const cMinecart &>(a_Entity);
-			a_Pkt.WriteInt((((a_Entity.GetMaxHealth() / 2) - (a_Entity.GetHealth() - (a_Entity.GetMaxHealth() / 2))) * Minecart.LastDamage()) * 4);
-			a_Pkt.WriteByte(0x52);
-			a_Pkt.WriteInt(1);  // Shaking direction, doesn't seem to affect anything
-			a_Pkt.WriteByte(0x73);
-			a_Pkt.WriteFloat(static_cast<float>(Minecart.LastDamage() + 10));  // Damage taken / shake effect multiplyer
+			a_Pkt.WriteBEInt32((((a_Entity.GetMaxHealth() / 2) - (a_Entity.GetHealth() - (a_Entity.GetMaxHealth() / 2))) * Minecart.LastDamage()) * 4);
+			a_Pkt.WriteBEUInt8(0x52);
+			a_Pkt.WriteBEInt32(1);  // Shaking direction, doesn't seem to affect anything
+			a_Pkt.WriteBEUInt8(0x73);
+			a_Pkt.WriteBEFloat(static_cast<float>(Minecart.LastDamage() + 10));  // Damage taken / shake effect multiplyer
 			
 			if (Minecart.GetPayload() == cMinecart::mpNone)
 			{
@@ -3074,20 +3077,20 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 				const cItem & MinecartContent = RideableMinecart.GetContent();
 				if (!MinecartContent.IsEmpty())
 				{
-					a_Pkt.WriteByte(0x54);
+					a_Pkt.WriteBEUInt8(0x54);
 					int Content = MinecartContent.m_ItemType;
 					Content |= MinecartContent.m_ItemDamage << 8;
-					a_Pkt.WriteInt(Content);
-					a_Pkt.WriteByte(0x55);
-					a_Pkt.WriteInt(RideableMinecart.GetBlockHeight());
-					a_Pkt.WriteByte(0x56);
-					a_Pkt.WriteByte(1);
+					a_Pkt.WriteBEInt32(Content);
+					a_Pkt.WriteBEUInt8(0x55);
+					a_Pkt.WriteBEInt32(RideableMinecart.GetBlockHeight());
+					a_Pkt.WriteBEUInt8(0x56);
+					a_Pkt.WriteBEUInt8(1);
 				}
 			}
 			else if (Minecart.GetPayload() == cMinecart::mpFurnace)
 			{
-				a_Pkt.WriteByte(0x10);
-				a_Pkt.WriteByte(reinterpret_cast<const cMinecartWithFurnace &>(Minecart).IsFueled() ? 1 : 0);
+				a_Pkt.WriteBEUInt8(0x10);
+				a_Pkt.WriteBEUInt8(reinterpret_cast<const cMinecartWithFurnace &>(Minecart).IsFueled() ? 1 : 0);
 			}
 			break;
 		}  // case etMinecart
@@ -3099,13 +3102,13 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 			{
 				case cProjectileEntity::pkArrow:
 				{
-					a_Pkt.WriteByte(0x10);
-					a_Pkt.WriteByte(reinterpret_cast<const cArrowEntity &>(Projectile).IsCritical() ? 1 : 0);
+					a_Pkt.WriteBEUInt8(0x10);
+					a_Pkt.WriteBEUInt8(reinterpret_cast<const cArrowEntity &>(Projectile).IsCritical() ? 1 : 0);
 					break;
 				}
 				case cProjectileEntity::pkFirework:
 				{
-					a_Pkt.WriteByte(0xa8);
+					a_Pkt.WriteBEUInt8(0xa8);
 					WriteItem(a_Pkt, reinterpret_cast<const cFireworkEntity &>(Projectile).GetItem());
 					break;
 				}
@@ -3126,10 +3129,10 @@ void cProtocol180::WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_En
 		case cEntity::etItemFrame:
 		{
 			auto & Frame = reinterpret_cast<const cItemFrame &>(a_Entity);
-			a_Pkt.WriteByte(0xa8);
+			a_Pkt.WriteBEUInt8(0xa8);
 			WriteItem(a_Pkt, Frame.GetItem());
-			a_Pkt.WriteByte(0x09);
-			a_Pkt.WriteByte(Frame.GetItemRotation());
+			a_Pkt.WriteBEUInt8(0x09);
+			a_Pkt.WriteBEUInt8(Frame.GetItemRotation());
 			break;
 		}  // case etItemFrame
 
@@ -3151,38 +3154,38 @@ void cProtocol180::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 		case mtBat:
 		{
 			auto & Bat = reinterpret_cast<const cBat &>(a_Mob);
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(Bat.IsHanging() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Bat.IsHanging() ? 1 : 0);
 			break;
 		}  // case mtBat
 		
 		case mtCreeper:
 		{
 			auto & Creeper = reinterpret_cast<const cCreeper &>(a_Mob);
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(Creeper.IsBlowing() ? 1 : -1);
-			a_Pkt.WriteByte(0x11);
-			a_Pkt.WriteByte(Creeper.IsCharged() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Creeper.IsBlowing() ? 1 : -1);
+			a_Pkt.WriteBEUInt8(0x11);
+			a_Pkt.WriteBEUInt8(Creeper.IsCharged() ? 1 : 0);
 			break;
 		}  // case mtCreeper
 		
 		case mtEnderman:
 		{
 			auto & Enderman = reinterpret_cast<const cEnderman &>(a_Mob);
-			a_Pkt.WriteByte(0x30);
-			a_Pkt.WriteShort(static_cast<Byte>(Enderman.GetCarriedBlock()));
-			a_Pkt.WriteByte(0x11);
-			a_Pkt.WriteByte(static_cast<Byte>(Enderman.GetCarriedMeta()));
-			a_Pkt.WriteByte(0x12);
-			a_Pkt.WriteByte(Enderman.IsScreaming() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x30);
+			a_Pkt.WriteBEInt16(static_cast<Byte>(Enderman.GetCarriedBlock()));
+			a_Pkt.WriteBEUInt8(0x11);
+			a_Pkt.WriteBEUInt8(static_cast<Byte>(Enderman.GetCarriedMeta()));
+			a_Pkt.WriteBEUInt8(0x12);
+			a_Pkt.WriteBEUInt8(Enderman.IsScreaming() ? 1 : 0);
 			break;
 		}  // case mtEnderman
 		
 		case mtGhast:
 		{
 			auto & Ghast = reinterpret_cast<const cGhast &>(a_Mob);
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(Ghast.IsCharging());
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Ghast.IsCharging());
 			break;
 		}  // case mtGhast
 		
@@ -3218,89 +3221,89 @@ void cProtocol180::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 			{
 				Flags |= 0x80;
 			}
-			a_Pkt.WriteByte(0x50);  // Int at index 16
-			a_Pkt.WriteInt(Flags);
-			a_Pkt.WriteByte(0x13);  // Byte at index 19
-			a_Pkt.WriteByte(Horse.GetHorseType());
-			a_Pkt.WriteByte(0x54);  // Int at index 20
+			a_Pkt.WriteBEUInt8(0x50);  // Int at index 16
+			a_Pkt.WriteBEInt32(Flags);
+			a_Pkt.WriteBEUInt8(0x13);  // Byte at index 19
+			a_Pkt.WriteBEUInt8(Horse.GetHorseType());
+			a_Pkt.WriteBEUInt8(0x54);  // Int at index 20
 			int Appearance = 0;
 			Appearance = Horse.GetHorseColor();
 			Appearance |= Horse.GetHorseStyle() << 8;
-			a_Pkt.WriteInt(Appearance);
-			a_Pkt.WriteByte(0x56);  // Int at index 22
-			a_Pkt.WriteInt(Horse.GetHorseArmour());
+			a_Pkt.WriteBEInt32(Appearance);
+			a_Pkt.WriteBEUInt8(0x56);  // Int at index 22
+			a_Pkt.WriteBEInt32(Horse.GetHorseArmour());
 			break;
 		}  // case mtHorse
 
 		case mtMagmaCube:
 		{
 			auto & MagmaCube = reinterpret_cast<const cMagmaCube &>(a_Mob);
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(MagmaCube.GetSize());
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(MagmaCube.GetSize());
 			break;
 		}  // case mtMagmaCube
 
 		case mtPig:
 		{
 			auto & Pig = reinterpret_cast<const cPig &>(a_Mob);
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(Pig.IsSaddled() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Pig.IsSaddled() ? 1 : 0);
 			break;
 		}  // case mtPig
 		
 		case mtSheep:
 		{
 			auto & Sheep = reinterpret_cast<const cSheep &>(a_Mob);
-			a_Pkt.WriteByte(0x10);
+			a_Pkt.WriteBEUInt8(0x10);
 			Byte SheepMetadata = 0;
 			SheepMetadata = Sheep.GetFurColor();
 			if (Sheep.IsSheared())
 			{
 				SheepMetadata |= 0x10;
 			}
-			a_Pkt.WriteByte(SheepMetadata);
+			a_Pkt.WriteBEUInt8(SheepMetadata);
 			break;
 		}  // case mtSheep
 		
 		case mtSkeleton:
 		{
 			auto & Skeleton = reinterpret_cast<const cSkeleton &>(a_Mob);
-			a_Pkt.WriteByte(0x0d);
-			a_Pkt.WriteByte(Skeleton.IsWither() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0d);
+			a_Pkt.WriteBEUInt8(Skeleton.IsWither() ? 1 : 0);
 			break;
 		}  // case mtSkeleton
 		
 		case mtSlime:
 		{
 			auto & Slime = reinterpret_cast<const cSlime &>(a_Mob);
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(Slime.GetSize());
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(Slime.GetSize());
 			break;
 		}  // case mtSlime
 
 		case mtVillager:
 		{
 			auto & Villager = reinterpret_cast<const cVillager &>(a_Mob);
-			a_Pkt.WriteByte(0x50);
-			a_Pkt.WriteInt(Villager.GetVilType());
+			a_Pkt.WriteBEUInt8(0x50);
+			a_Pkt.WriteBEInt32(Villager.GetVilType());
 			break;
 		}  // case mtVillager
 		
 		case mtWitch:
 		{
 			auto & Witch = reinterpret_cast<const cWitch &>(a_Mob);
-			a_Pkt.WriteByte(0x15);
-			a_Pkt.WriteByte(Witch.IsAngry() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x15);
+			a_Pkt.WriteBEUInt8(Witch.IsAngry() ? 1 : 0);
 			break;
 		}  // case mtWitch
 
 		case mtWither:
 		{
 			auto & Wither = reinterpret_cast<const cWither &>(a_Mob);
-			a_Pkt.WriteByte(0x54);  // Int at index 20
-			a_Pkt.WriteInt(Wither.GetWitherInvulnerableTicks());
-			a_Pkt.WriteByte(0x66);  // Float at index 6
-			a_Pkt.WriteFloat(static_cast<float>(a_Mob.GetHealth()));
+			a_Pkt.WriteBEUInt8(0x54);  // Int at index 20
+			a_Pkt.WriteBEInt32(Wither.GetWitherInvulnerableTicks());
+			a_Pkt.WriteBEUInt8(0x66);  // Float at index 6
+			a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
 			break;
 		}  // case mtWither
 		
@@ -3320,27 +3323,27 @@ void cProtocol180::WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob)
 			{
 				WolfStatus |= 0x4;
 			}
-			a_Pkt.WriteByte(0x10);
-			a_Pkt.WriteByte(WolfStatus);
+			a_Pkt.WriteBEUInt8(0x10);
+			a_Pkt.WriteBEUInt8(WolfStatus);
 
-			a_Pkt.WriteByte(0x72);
-			a_Pkt.WriteFloat(static_cast<float>(a_Mob.GetHealth()));
-			a_Pkt.WriteByte(0x13);
-			a_Pkt.WriteByte(Wolf.IsBegging() ? 1 : 0);
-			a_Pkt.WriteByte(0x14);
-			a_Pkt.WriteByte(Wolf.GetCollarColor());
+			a_Pkt.WriteBEUInt8(0x72);
+			a_Pkt.WriteBEFloat(static_cast<float>(a_Mob.GetHealth()));
+			a_Pkt.WriteBEUInt8(0x13);
+			a_Pkt.WriteBEUInt8(Wolf.IsBegging() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x14);
+			a_Pkt.WriteBEUInt8(Wolf.GetCollarColor());
 			break;
 		}  // case mtWolf
 		
 		case mtZombie:
 		{
 			auto & Zombie = reinterpret_cast<const cZombie &>(a_Mob);
-			a_Pkt.WriteByte(0x0c);
-			a_Pkt.WriteByte(Zombie.IsBaby() ? 1 : 0);
-			a_Pkt.WriteByte(0x0d);
-			a_Pkt.WriteByte(Zombie.IsVillagerZombie() ? 1 : 0);
-			a_Pkt.WriteByte(0x0e);
-			a_Pkt.WriteByte(Zombie.IsConverting() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0c);
+			a_Pkt.WriteBEUInt8(Zombie.IsBaby() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0d);
+			a_Pkt.WriteBEUInt8(Zombie.IsVillagerZombie() ? 1 : 0);
+			a_Pkt.WriteBEUInt8(0x0e);
+			a_Pkt.WriteBEUInt8(Zombie.IsConverting() ? 1 : 0);
 			break;
 		}  // case mtZombie
 	}  // switch (a_Mob.GetType())
@@ -3355,7 +3358,7 @@ void cProtocol180::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_
 	if (!a_Entity.IsMob())
 	{
 		// No properties for anything else than mobs
-		a_Pkt.WriteInt(0);
+		a_Pkt.WriteBEInt32(0);
 		return;
 	}
 
@@ -3363,7 +3366,7 @@ void cProtocol180::WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_
 
 	// TODO: Send properties and modifiers based on the mob type
 	
-	a_Pkt.WriteInt(0);  // NumProperties
+	a_Pkt.WriteBEInt32(0);  // NumProperties
 }
 
 

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -186,7 +186,7 @@ void cProtocol180::SendBlockAction(int a_BlockX, int a_BlockY, int a_BlockZ, cha
 
 
 
-void cProtocol180::SendBlockBreakAnim(int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
+void cProtocol180::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
 {
 	ASSERT(m_State == 3);  // In game mode?
 	

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -162,8 +162,8 @@ void cProtocol180::SendAttachEntity(const cEntity & a_Entity, const cEntity * a_
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1b);  // Attach Entity packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
-	Pkt.WriteInt((a_Vehicle != nullptr) ? a_Vehicle->GetUniqueID() : 0);
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32((a_Vehicle != nullptr) ? a_Vehicle->GetUniqueID() : 0);
 	Pkt.WriteBool(false);
 }
 
@@ -363,7 +363,7 @@ void cProtocol180::SendEntityEquipment(const cEntity & a_Entity, short a_SlotNum
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x04);  // Entity Equipment packet
-	Pkt.WriteVarInt((UInt32)a_Entity.GetUniqueID());
+	Pkt.WriteVarInt(a_Entity.GetUniqueID());
 	Pkt.WriteShort(a_SlotNum);
 	Pkt.WriteItem(a_Item);
 }
@@ -377,7 +377,7 @@ void cProtocol180::SendEntityHeadLook(const cEntity & a_Entity)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x19);  // Entity Head Look packet
-	Pkt.WriteVarInt((UInt32)a_Entity.GetUniqueID());
+	Pkt.WriteVarInt(a_Entity.GetUniqueID());
 	Pkt.WriteByteAngle(a_Entity.GetHeadYaw());
 }
 
@@ -433,9 +433,9 @@ void cProtocol180::SendEntityRelMove(const cEntity & a_Entity, char a_RelX, char
 	
 	cPacketizer Pkt(*this, 0x15);  // Entity Relative Move packet
 	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteByte(a_RelX);
-	Pkt.WriteByte(a_RelY);
-	Pkt.WriteByte(a_RelZ);
+	Pkt.WriteChar(a_RelX);
+	Pkt.WriteChar(a_RelY);
+	Pkt.WriteChar(a_RelZ);
 	Pkt.WriteBool(a_Entity.IsOnGround());
 }
 
@@ -449,9 +449,9 @@ void cProtocol180::SendEntityRelMoveLook(const cEntity & a_Entity, char a_RelX, 
 	
 	cPacketizer Pkt(*this, 0x17);  // Entity Look And Relative Move packet
 	Pkt.WriteVarInt(a_Entity.GetUniqueID());
-	Pkt.WriteByte(a_RelX);
-	Pkt.WriteByte(a_RelY);
-	Pkt.WriteByte(a_RelZ);
+	Pkt.WriteChar(a_RelX);
+	Pkt.WriteChar(a_RelY);
+	Pkt.WriteChar(a_RelZ);
 	Pkt.WriteByteAngle(a_Entity.GetYaw());
 	Pkt.WriteByteAngle(a_Entity.GetPitch());
 	Pkt.WriteBool(a_Entity.IsOnGround());
@@ -466,7 +466,7 @@ void cProtocol180::SendEntityStatus(const cEntity & a_Entity, char a_Status)
 	ASSERT(m_State == 3);  // In game mode?
 	
 	cPacketizer Pkt(*this, 0x1a);  // Entity Status packet
-	Pkt.WriteInt(a_Entity.GetUniqueID());
+	Pkt.WriteUInt32(a_Entity.GetUniqueID());
 	Pkt.WriteChar(a_Status);
 }
 
@@ -580,7 +580,7 @@ void cProtocol180::SendLogin(const cPlayer & a_Player, const cWorld & a_World)
 	{
 		cServer * Server = cRoot::Get()->GetServer();
 		cPacketizer Pkt(*this, 0x01);  // Join Game packet
-		Pkt.WriteInt(a_Player.GetUniqueID());
+		Pkt.WriteUInt32(a_Player.GetUniqueID());
 		Pkt.WriteByte((Byte)a_Player.GetEffectiveGameMode() | (Server->IsHardcore() ? 0x08 : 0));  // Hardcore flag bit 4
 		Pkt.WriteChar((char)a_World.GetDimension());
 		Pkt.WriteByte(2);  // TODO: Difficulty (set to Normal)

--- a/src/Protocol/Protocol18x.h
+++ b/src/Protocol/Protocol18x.h
@@ -150,101 +150,6 @@ public:
 
 protected:
 
-	/** Composes individual packets in the protocol's m_OutPacketBuffer; sends them upon being destructed */
-	class cPacketizer
-	{
-	public:
-		cPacketizer(cProtocol180 & a_Protocol, UInt32 a_PacketType) :
-			m_Protocol(a_Protocol),
-			m_Out(a_Protocol.m_OutPacketBuffer),
-			m_Lock(a_Protocol.m_CSPacket)
-		{
-			m_Out.WriteVarInt(a_PacketType);
-		}
-		
-		~cPacketizer();
-
-		void WriteBool(bool a_Value)
-		{
-			m_Out.WriteBool(a_Value);
-		}
-		
-		void WriteByte(UInt8 a_Value)
-		{
-			m_Out.WriteBEUInt8(a_Value);
-		}
-		
-		void WriteChar(Int8 a_Value)
-		{
-			m_Out.WriteBEInt8(a_Value);
-		}
-		
-		void WriteShort(Int16 a_Value)
-		{
-			m_Out.WriteBEInt16(a_Value);
-		}
-		
-		void WriteInt(Int32 a_Value)
-		{
-			m_Out.WriteBEInt32(a_Value);
-		}
-		
-		void WriteUInt32(UInt32 a_Value)
-		{
-			m_Out.WriteBEUInt32(a_Value);
-		}
-		
-		void WriteInt64(Int64 a_Value)
-		{
-			m_Out.WriteBEInt64(a_Value);
-		}
-		
-		void WriteFloat(float a_Value)
-		{
-			m_Out.WriteBEFloat(a_Value);
-		}
-		
-		void WriteDouble(double a_Value)
-		{
-			m_Out.WriteBEDouble(a_Value);
-		}
-		
-		void WriteVarInt(UInt32 a_Value)
-		{
-			m_Out.WriteVarInt(a_Value);
-		}
-		
-		void WriteString(const AString & a_Value)
-		{
-			m_Out.WriteVarUTF8String(a_Value);
-		}
-
-		void WritePosition(int a_BlockX, int a_BlockY, int a_BlockZ)
-		{
-			m_Out.WritePosition(a_BlockX, a_BlockY, a_BlockZ);
-		}
-		
-		void WriteUUID(const AString & a_UUID);
-		
-		void WriteBuf(const char * a_Data, size_t a_Size)
-		{
-			m_Out.Write(a_Data, a_Size);
-		}
-		
-		void WriteItem(const cItem & a_Item);
-		void WriteByteAngle(double a_Angle);  // Writes the specified angle using a single byte
-		void WriteFPInt(double a_Value);  // Writes the double value as a 27:5 fixed-point integer
-		void WriteEntityMetadata(const cEntity & a_Entity);  // Writes the metadata for the specified entity, not including the terminating 0x7f
-		void WriteMobMetadata(const cMonster & a_Mob);  // Writes the mob-specific metadata for the specified mob
-		void WriteEntityProperties(const cEntity & a_Entity);  // Writes the entity properties for the specified entity, including the Count field
-		void WriteBlockEntity(const cBlockEntity & a_BlockEntity);
-		
-	protected:
-		cProtocol180 & m_Protocol;
-		cByteBuffer & m_Out;
-		cCSLock m_Lock;
-	} ;
-
 	AString m_ServerAddress;
 	
 	UInt16 m_ServerPort;
@@ -256,12 +161,6 @@ protected:
 
 	/** Buffer for the received data */
 	cByteBuffer m_ReceivedData;
-	
-	/** Buffer for composing the outgoing packets, through cPacketizer */
-	cByteBuffer m_OutPacketBuffer;
-	
-	/** Buffer for composing packet length (so that each cPacketizer instance doesn't allocate a new cPacketBuffer) */
-	cByteBuffer m_OutPacketLenBuffer;
 	
 	bool m_IsEncrypted;
 	
@@ -325,6 +224,9 @@ protected:
 	/** Sends the data to the client, encrypting them if needed. */
 	virtual void SendData(const char * a_Data, size_t a_Size) override;
 
+	/** Sends the packet to the client. Called by the cPacketizer's destructor. */
+	virtual void SendPacket(cPacketizer & a_Packet) override;
+
 	void SendCompass(const cWorld & a_World);
 	
 	/** Reads an item out of the received data, sets a_Item to the values read.
@@ -340,6 +242,21 @@ protected:
 	/** Converts the BlockFace received by the protocol into eBlockFace constants.
 	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
 	eBlockFace FaceIntToBlockFace(Int8 a_FaceInt);
+
+	/** Writes the item data into a packet. */
+	void WriteItem(cPacketizer & a_Pkt, const cItem & a_Item);
+
+	/** Writes the metadata for the specified entity, not including the terminating 0x7f. */
+	void WriteEntityMetadata(cPacketizer & a_Pkt, const cEntity & a_Entity);
+
+	/** Writes the mob-specific metadata for the specified mob */
+	void WriteMobMetadata(cPacketizer & a_Pkt, const cMonster & a_Mob);
+
+	/** Writes the entity properties for the specified entity, including the Count field. */
+	void WriteEntityProperties(cPacketizer & a_Pkt, const cEntity & a_Entity);
+
+	/** Writes the block entity data for the specified block entity into the packet. */
+	void WriteBlockEntity(cPacketizer & a_Pkt, const cBlockEntity & a_BlockEntity);
 } ;
 
 

--- a/src/Protocol/Protocol18x.h
+++ b/src/Protocol/Protocol18x.h
@@ -189,6 +189,11 @@ protected:
 			m_Out.WriteBEInt32(a_Value);
 		}
 		
+		void WriteUInt32(UInt32 a_Value)
+		{
+			m_Out.WriteBEUInt32(a_Value);
+		}
+		
 		void WriteInt64(Int64 a_Value)
 		{
 			m_Out.WriteBEInt64(a_Value);

--- a/src/Protocol/Protocol18x.h
+++ b/src/Protocol/Protocol18x.h
@@ -62,7 +62,7 @@ public:
 	/** Sending stuff to clients (alphabetically sorted): */
 	virtual void SendAttachEntity               (const cEntity & a_Entity, const cEntity * a_Vehicle) override;
 	virtual void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType) override;
-	virtual void SendBlockBreakAnim	            (int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) override;
+	virtual void SendBlockBreakAnim	            (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) override;
 	virtual void SendBlockChange                (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) override;
 	virtual void SendBlockChanges               (int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes) override;
 	virtual void SendChat                       (const AString & a_Message) override;

--- a/src/Protocol/Protocol18x.h
+++ b/src/Protocol/Protocol18x.h
@@ -169,24 +169,24 @@ protected:
 			m_Out.WriteBool(a_Value);
 		}
 		
-		void WriteByte(Byte a_Value)
+		void WriteByte(UInt8 a_Value)
 		{
-			m_Out.WriteByte(a_Value);
+			m_Out.WriteBEUInt8(a_Value);
 		}
 		
-		void WriteChar(char a_Value)
+		void WriteChar(Int8 a_Value)
 		{
-			m_Out.WriteChar(a_Value);
+			m_Out.WriteBEInt8(a_Value);
 		}
 		
-		void WriteShort(short a_Value)
+		void WriteShort(Int16 a_Value)
 		{
-			m_Out.WriteBEShort(a_Value);
+			m_Out.WriteBEInt16(a_Value);
 		}
 		
-		void WriteInt(int a_Value)
+		void WriteInt(Int32 a_Value)
 		{
-			m_Out.WriteBEInt(a_Value);
+			m_Out.WriteBEInt32(a_Value);
 		}
 		
 		void WriteInt64(Int64 a_Value)
@@ -332,6 +332,9 @@ protected:
 	
 	void StartEncryption(const Byte * a_Key);
 
+	/** Converts the BlockFace received by the protocol into eBlockFace constants.
+	If the received value doesn't match any of our eBlockFace constants, BLOCK_FACE_NONE is returned. */
+	eBlockFace FaceIntToBlockFace(Int8 a_FaceInt);
 } ;
 
 

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -982,3 +982,15 @@ bool cProtocolRecognizer::TryRecognizeLengthedProtocol(UInt32 a_PacketLengthRema
 
 
 
+void cProtocolRecognizer::SendPacket(cPacketizer & a_Pkt)
+{
+	// This function should never be called - it needs to exists so that cProtocolRecognizer can be instantiated,
+	// but the actual sending is done by the internal m_Protocol itself.
+	LOGWARNING("%s: This function shouldn't ever be called.", __FUNCTION__);
+	ASSERT(!"Function not to be called");
+}
+
+
+
+
+

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -911,13 +911,13 @@ bool cProtocolRecognizer::TryRecognizeLengthedProtocol(UInt32 a_PacketLengthRema
 		case PROTO_VERSION_1_7_2:
 		{
 			AString ServerAddress;
-			short ServerPort;
+			UInt16 ServerPort;
 			UInt32 NextState;
 			if (!m_Buffer.ReadVarUTF8String(ServerAddress))
 			{
 				break;
 			}
-			if (!m_Buffer.ReadBEShort(ServerPort))
+			if (!m_Buffer.ReadBEUInt16(ServerPort))
 			{
 				break;
 			}
@@ -926,19 +926,19 @@ bool cProtocolRecognizer::TryRecognizeLengthedProtocol(UInt32 a_PacketLengthRema
 				break;
 			}
 			m_Buffer.CommitRead();
-			m_Protocol = new cProtocol172(m_Client, ServerAddress, (UInt16)ServerPort, NextState);
+			m_Protocol = new cProtocol172(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 		case PROTO_VERSION_1_7_6:
 		{
 			AString ServerAddress;
-			short ServerPort;
+			UInt16 ServerPort;
 			UInt32 NextState;
 			if (!m_Buffer.ReadVarUTF8String(ServerAddress))
 			{
 				break;
 			}
-			if (!m_Buffer.ReadBEShort(ServerPort))
+			if (!m_Buffer.ReadBEUInt16(ServerPort))
 			{
 				break;
 			}
@@ -947,19 +947,19 @@ bool cProtocolRecognizer::TryRecognizeLengthedProtocol(UInt32 a_PacketLengthRema
 				break;
 			}
 			m_Buffer.CommitRead();
-			m_Protocol = new cProtocol176(m_Client, ServerAddress, (UInt16)ServerPort, NextState);
+			m_Protocol = new cProtocol176(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 		case PROTO_VERSION_1_8_0:
 		{
 			AString ServerAddress;
-			short ServerPort;
+			UInt16 ServerPort;
 			UInt32 NextState;
 			if (!m_Buffer.ReadVarUTF8String(ServerAddress))
 			{
 				break;
 			}
-			if (!m_Buffer.ReadBEShort(ServerPort))
+			if (!m_Buffer.ReadBEUInt16(ServerPort))
 			{
 				break;
 			}
@@ -968,12 +968,12 @@ bool cProtocolRecognizer::TryRecognizeLengthedProtocol(UInt32 a_PacketLengthRema
 				break;
 			}
 			m_Buffer.CommitRead();
-			m_Protocol = new cProtocol180(m_Client, ServerAddress, (UInt16)ServerPort, NextState);
+			m_Protocol = new cProtocol180(m_Client, ServerAddress, ServerPort, NextState);
 			return true;
 		}
 	}
-	LOGINFO("Client \"%s\" uses an unsupported protocol (lengthed, version %u)",
-		m_Client->GetIPString().c_str(), ProtocolVersion
+	LOGINFO("Client \"%s\" uses an unsupported protocol (lengthed, version %u (0x%x))",
+		m_Client->GetIPString().c_str(), ProtocolVersion, ProtocolVersion
 	);
 	m_Client->Kick("Unsupported protocol version");
 	return false;

--- a/src/Protocol/ProtocolRecognizer.cpp
+++ b/src/Protocol/ProtocolRecognizer.cpp
@@ -108,10 +108,10 @@ void cProtocolRecognizer::SendBlockAction(int a_BlockX, int a_BlockY, int a_Bloc
 
 
 
-void cProtocolRecognizer::SendBlockBreakAnim(int a_entityID, int a_BlockX, int a_BlockY, int a_BlockZ, char stage)
+void cProtocolRecognizer::SendBlockBreakAnim(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage)
 {
 	ASSERT(m_Protocol != nullptr);
-	m_Protocol->SendBlockBreakAnim(a_entityID, a_BlockX, a_BlockY, a_BlockZ, stage);
+	m_Protocol->SendBlockBreakAnim(a_EntityID, a_BlockX, a_BlockY, a_BlockZ, a_Stage);
 }
 
 

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -50,7 +50,7 @@ public:
 	/// Sending stuff to clients (alphabetically sorted):
 	virtual void SendAttachEntity               (const cEntity & a_Entity, const cEntity * a_Vehicle) override;
 	virtual void SendBlockAction                (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType) override;
-	virtual void SendBlockBreakAnim             (int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) override;
+	virtual void SendBlockBreakAnim             (UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage) override;
 	virtual void SendBlockChange                (int a_BlockX, int a_BlockY, int a_BlockZ, BLOCKTYPE a_BlockType, NIBBLETYPE a_BlockMeta) override;
 	virtual void SendBlockChanges               (int a_ChunkX, int a_ChunkZ, const sSetBlockVector & a_Changes) override;
 	virtual void SendChat                       (const AString & a_Message) override;

--- a/src/Protocol/ProtocolRecognizer.h
+++ b/src/Protocol/ProtocolRecognizer.h
@@ -136,9 +136,12 @@ protected:
 	
 	/** Tries to recognize a protocol in the lengthed family (1.7+), based on m_Buffer; returns true if recognized.
 	The packet length and type have already been read, type is 0
-	The number of bytes remaining in the packet is passed as a_PacketLengthRemaining
-	**/
+	The number of bytes remaining in the packet is passed as a_PacketLengthRemaining. **/
 	bool TryRecognizeLengthedProtocol(UInt32 a_PacketLengthRemaining);
+
+	/** Sends a single packet contained within the cPacketizer class.
+	The cPacketizer's destructor calls this to send the contained packet; protocol may transform the data (compression in 1.8 etc). */
+	virtual void SendPacket(cPacketizer & a_Pkt) override;
 } ;
 
 

--- a/src/UI/SlotArea.h
+++ b/src/UI/SlotArea.h
@@ -248,28 +248,31 @@ public:
 
 
 protected:
-	/// Maps player's EntityID -> current recipe; not a std::map because cCraftingGrid needs proper constructor params
-	typedef std::list<std::pair<int, cCraftingRecipe> > cRecipeMap;
+	/** Maps player's EntityID -> current recipe.
+	Not a std::map because cCraftingGrid needs proper constructor params. */
+	typedef std::list<std::pair<UInt32, cCraftingRecipe> > cRecipeMap;
 	
 	int        m_GridSize;
 	cRecipeMap m_Recipes;
 	
-	/// Handles a click in the result slot. Crafts using the current recipe, if possible
+	/** Handles a click in the result slot.
+	Crafts using the current recipe, if possible. */
 	void ClickedResult(cPlayer & a_Player);
 	
-	/// Handles a shift-click in the result slot. Crafts using the current recipe until it changes or no more space for result.
+	/** Handles a shift-click in the result slot.
+	Crafts using the current recipe until it changes or no more space for result. */
 	void ShiftClickedResult(cPlayer & a_Player);
 
 	/** Handles a drop-click in the result slot. */
 	void DropClickedResult(cPlayer & a_Player);
 
-	/// Updates the current recipe and result slot based on the ingredients currently in the crafting grid of the specified player
+	/** Updates the current recipe and result slot based on the ingredients currently in the crafting grid of the specified player. */
 	void UpdateRecipe(cPlayer & a_Player);
 	
-	/// Retrieves the recipe for the specified player from the map, or creates one if not found
+	/** Retrieves the recipe for the specified player from the map, or creates one if not found. */
 	cCraftingRecipe & GetRecipeForPlayer(cPlayer & a_Player);
 
-	/// Called after an item has been crafted to handle statistics e.t.c.
+	/** Called after an item has been crafted to handle statistics e.t.c. */
 	void HandleCraftItem(const cItem & a_Result, cPlayer & a_Player);
 } ;
 

--- a/src/World.h
+++ b/src/World.h
@@ -215,7 +215,7 @@ public:
 	// (Please keep these alpha-sorted)
 	void BroadcastAttachEntity       (const cEntity & a_Entity, const cEntity * a_Vehicle);
 	void BroadcastBlockAction        (int a_BlockX, int a_BlockY, int a_BlockZ, char a_Byte1, char a_Byte2, BLOCKTYPE a_BlockType, const cClientHandle * a_Exclude = nullptr);  // tolua_export
-	void BroadcastBlockBreakAnimation(int a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude = nullptr);
+	void BroadcastBlockBreakAnimation(UInt32 a_EntityID, int a_BlockX, int a_BlockY, int a_BlockZ, char a_Stage, const cClientHandle * a_Exclude = nullptr);
 	void BroadcastBlockEntity        (int a_BlockX, int a_BlockY, int a_BlockZ, const cClientHandle * a_Exclude = nullptr);  ///< If there is a block entity at the specified coods, sends it to all clients except a_Exclude
 
 	// tolua_begin
@@ -335,7 +335,9 @@ public:
 	The entity is added lazily - this function only puts it in a queue that is then processed by the Tick thread. */
 	void AddEntity(cEntity * a_Entity);
 	
-	bool HasEntity(int a_UniqueID);
+	/** Returns true if an entity with the specified UniqueID exists in the world.
+	Note: Only loaded chunks are considered. */
+	bool HasEntity(UInt32 a_UniqueID);
 	
 	/** Calls the callback for each entity in the entire world; returns true if all entities processed, false if the callback aborted by returning true */
 	bool ForEachEntity(cEntityCallback & a_Callback);  // Exported in ManualBindings.cpp
@@ -348,8 +350,9 @@ public:
 	If any chunk in the box is missing, ignores the entities in that chunk silently. */
 	bool ForEachEntityInBox(const cBoundingBox & a_Box, cEntityCallback & a_Callback);  // Exported in ManualBindings.cpp
 
-	/** Calls the callback if the entity with the specified ID is found, with the entity object as the callback param. Returns true if entity found and callback returned false. */
-	bool DoWithEntityByID(int a_UniqueID, cEntityCallback & a_Callback);  // Exported in ManualBindings.cpp
+	/** Calls the callback if the entity with the specified ID is found, with the entity object as the callback param.
+	Returns true if entity found and callback returned false. */
+	bool DoWithEntityByID(UInt32 a_UniqueID, cEntityCallback & a_Callback);  // Exported in ManualBindings.cpp
 
 	/** Compares clients of two chunks, calls the callback accordingly */
 	void CompareChunkClients(int a_ChunkX1, int a_ChunkZ1, int a_ChunkX2, int a_ChunkZ2, cClientDiffCallback & a_Callback);
@@ -476,20 +479,25 @@ public:
 	/** Spawns item pickups for each item in the list. May compress pickups if too many entities: */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_FlyAwaySpeed = 1.0, bool IsPlayerCreated = false) override;
 	
-	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified: */
+	/** Spawns item pickups for each item in the list. May compress pickups if too many entities. All pickups get the speed specified. */
 	virtual void SpawnItemPickups(const cItems & a_Pickups, double a_BlockX, double a_BlockY, double a_BlockZ, double a_SpeedX, double a_SpeedY, double a_SpeedZ, bool IsPlayerCreated = false) override;
 	
-	/** Spawns an falling block entity at the given position. It returns the UniqueID of the spawned falling block. */
-	int SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE BlockType, NIBBLETYPE BlockMeta);
+	/** Spawns an falling block entity at the given position.
+	Returns the UniqueID of the spawned falling block, or cEntity::INVALID_ID on failure. */
+	UInt32 SpawnFallingBlock(int a_X, int a_Y, int a_Z, BLOCKTYPE BlockType, NIBBLETYPE BlockMeta);
 
-	/** Spawns an minecart at the given coordinates. */
-	int SpawnMinecart(double a_X, double a_Y, double a_Z, int a_MinecartType, const cItem & a_Content = cItem(), int a_BlockHeight = 1);
+	/** Spawns an minecart at the given coordinates.
+	Returns the UniqueID of the spawned minecart, or cEntity::INVALID_ID on failure. */
+	UInt32 SpawnMinecart(double a_X, double a_Y, double a_Z, int a_MinecartType, const cItem & a_Content = cItem(), int a_BlockHeight = 1);
 
-	/** Spawns an experience orb at the given location with the given reward. It returns the UniqueID of the spawned experience orb. */
-	virtual int SpawnExperienceOrb(double a_X, double a_Y, double a_Z, int a_Reward) override;
+	/** Spawns an experience orb at the given location with the given reward.
+	Returns the UniqueID of the spawned experience orb, or cEntity::INVALID_ID on failure. */
+	virtual UInt32 SpawnExperienceOrb(double a_X, double a_Y, double a_Z, int a_Reward) override;
 
-	/** Spawns a new primed TNT entity at the specified block coords and specified fuse duration. Initial velocity is given based on the relative coefficient provided */
-	void SpawnPrimedTNT(double a_X, double a_Y, double a_Z, int a_FuseTimeInSec = 80, double a_InitialVelocityCoeff = 1);
+	/** Spawns a new primed TNT entity at the specified block coords and specified fuse duration.
+	Initial velocity is given based on the relative coefficient provided.
+	Returns the UniqueID of the created entity, or cEntity::INVALID_ID on failure. */
+	UInt32 SpawnPrimedTNT(double a_X, double a_Y, double a_Z, int a_FuseTimeInSec = 80, double a_InitialVelocityCoeff = 1);
 
 	// tolua_end
 
@@ -796,14 +804,14 @@ public:
 
 	bool IsBlockDirectlyWatered(int a_BlockX, int a_BlockY, int a_BlockZ);  // tolua_export
 	
-	/** Spawns a mob of the specified type. Returns the mob's EntityID if recognized and spawned, <0 otherwise */
-	virtual int SpawnMob(double a_PosX, double a_PosY, double a_PosZ, eMonsterType a_MonsterType) override;  // tolua_export
-	int SpawnMobFinalize(cMonster* a_Monster);
+	/** Spawns a mob of the specified type. Returns the mob's UniqueID if recognized and spawned, cEntity::INVALID_ID otherwise */
+	virtual UInt32 SpawnMob(double a_PosX, double a_PosY, double a_PosZ, eMonsterType a_MonsterType) override;  // tolua_export
+
+	UInt32 SpawnMobFinalize(cMonster * a_Monster);
 	
-	/** Creates a projectile of the specified type. Returns the projectile's EntityID if successful, <0 otherwise
-	Item parameter used currently for Fireworks to correctly set entity metadata based on item metadata
-	*/
-	int CreateProjectile(double a_PosX, double a_PosY, double a_PosZ, cProjectileEntity::eKind a_Kind, cEntity * a_Creator, const cItem * a_Item, const Vector3d * a_Speed = nullptr);  // tolua_export
+	/** Creates a projectile of the specified type. Returns the projectile's UniqueID if successful, cEntity::INVALID_ID otherwise
+	Item parameter is currently used for Fireworks to correctly set entity metadata based on item metadata. */
+	UInt32 CreateProjectile(double a_PosX, double a_PosY, double a_PosZ, cProjectileEntity::eKind a_Kind, cEntity * a_Creator, const cItem * a_Item, const Vector3d * a_Speed = nullptr);  // tolua_export
 	
 	/** Returns a random number from the m_TickRand in range [0 .. a_Range]. To be used only in the tick thread! */
 	int GetTickRandomNumber(int a_Range) { return (int)(m_TickRand.randInt(a_Range)); }


### PR DESCRIPTION
Unified the two different `cPacketizer` classes inside the `cProtocol` descendants into a single shared class. The packetizer only writes the low-level datatypes, the high-level information (such as `cItem` data or mob metadata) is handled by the `cProtocol` descendants.