### PR TITLE
Added MobTypeName for Giant

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -38,6 +38,7 @@ static const struct
 	{mtEnderman,     "enderman",     "Enderman"},
 	{mtEnderDragon,  "enderdragon",  "EnderDragon"},
 	{mtGhast,        "ghast",        "Ghast"},
+	{mtGiant,        "giant",        "Giant"},
 	{mtGuardian,     "guardian",     "Guardian"},
 	{mtHorse,        "horse",        "EntityHorse"},
 	{mtIronGolem,    "irongolem",    "VillagerGolem"},


### PR DESCRIPTION
Added missing MobTypeName for Giant. This allows plugins like Essentials to spawn Giants.