### PR TITLE
Narrowed WindowID to use only 7 bits.

### DIFF
--- a/src/UI/Window.cpp
+++ b/src/UI/Window.cpp
@@ -21,19 +21,23 @@
 
 
 
-char cWindow::m_WindowIDCounter = 1;
+Byte cWindow::m_WindowIDCounter = 0;
 
 
 
 
 
 cWindow::cWindow(WindowType a_WindowType, const AString & a_WindowTitle) :
-	m_WindowID((++m_WindowIDCounter) % 127),
+	m_WindowID(static_cast<char>((++m_WindowIDCounter) % 127)),
 	m_WindowType(a_WindowType),
 	m_WindowTitle(a_WindowTitle),
 	m_IsDestroyed(false),
 	m_Owner(nullptr)
 {
+	// The window ID is signed in protocol 1.7, unsigned in protocol 1.8. Keep out of trouble by using only 7 bits:
+	// Ref.: http://forum.mc-server.org/showthread.php?tid=1876
+	ASSERT((m_WindowID >= 0) && (m_WindowID < 127));
+
 	if (a_WindowType == wtInventory)
 	{
 		m_WindowID = 0;

--- a/src/UI/Window.h
+++ b/src/UI/Window.h
@@ -185,7 +185,7 @@ protected:
 	
 	cWindowOwner * m_Owner;
 	
-	static char m_WindowIDCounter;
+	static Byte m_WindowIDCounter;
 
 	/// Sets the internal flag as "destroyed"; notifies the owner that the window is destroying
 	virtual void Destroy(void);


### PR DESCRIPTION
This fixes window issues reported on the forum, players are unable to interact with any windows after a while.

Ref.: http://forum.mc-server.org/showthread.php?tid=1876