### PR TITLE
cSetChunkData constructor explicitly requires std::move()

### DIFF
--- a/src/SetChunkData.cpp
+++ b/src/SetChunkData.cpp
@@ -33,8 +33,8 @@ cSetChunkData::cSetChunkData(
 	const NIBBLETYPE * a_SkyLight,
 	const cChunkDef::HeightMap * a_HeightMap,
 	const cChunkDef::BiomeMap * a_Biomes,
-	cEntityList & a_Entities,
-	cBlockEntityList & a_BlockEntities,
+	cEntityList && a_Entities,
+	cBlockEntityList && a_BlockEntities,
 	bool a_ShouldMarkDirty
 ) :
 	m_ChunkX(a_ChunkX),
@@ -84,8 +84,8 @@ cSetChunkData::cSetChunkData(
 	}
 	
 	// Move entities and blockentities:
-	std::swap(m_Entities,      a_Entities);
-	std::swap(m_BlockEntities, a_BlockEntities);
+	m_Entities = std::move(a_Entities);
+	m_BlockEntities = std::move(a_BlockEntities);
 }
 
 

--- a/src/SetChunkData.h
+++ b/src/SetChunkData.h
@@ -24,8 +24,10 @@ public:
 
 	/** Constructs a new instance based on data existing elsewhere, will copy all the memory. Prefer to use the
 	other constructor as much as possible.
-	Will move the entity and blockentity lists into the internal storage, and empty the a_Entities and
-	a_BlockEntities lists.
+	Will move the entity and blockentity lists into the internal storage, and invalidate a_Entities and
+	a_BlockEntities.
+	When passing an lvalue, a_Entities and a_BlockEntities must be explicitly converted to an rvalue beforehand
+	with std::move().
 	a_BlockTypes and a_BlockMetas must always be valid.
 	If either of the light arrays are nullptr, the chunk data will be marked as not having any light at all and
 	will be scheduled for re-lighting once it is set into the chunkmap.
@@ -41,8 +43,8 @@ public:
 		const NIBBLETYPE * a_SkyLight,
 		const cChunkDef::HeightMap * a_HeightMap,
 		const cChunkDef::BiomeMap * a_Biomes,
-		cEntityList & a_Entities,
-		cBlockEntityList & a_BlockEntities,
+		cEntityList && a_Entities,
+		cBlockEntityList && a_BlockEntities,
 		bool a_ShouldMarkDirty
 	);
 	

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -3712,7 +3712,7 @@ void cWorld::cChunkGeneratorCallbacks::OnChunkGenerated(cChunkDesc & a_ChunkDesc
 		a_ChunkDesc.GetBlockTypes(), BlockMetas,
 		nullptr, nullptr,  // We don't have lighting, chunk will be lighted when needed
 		&a_ChunkDesc.GetHeightMap(), &a_ChunkDesc.GetBiomeMap(),
-		a_ChunkDesc.GetEntities(), a_ChunkDesc.GetBlockEntities(),
+		std::move(a_ChunkDesc.GetEntities()), std::move(a_ChunkDesc.GetBlockEntities()),
 		true
 	));
 	SetChunkData->RemoveInvalidBlockEntities();

--- a/src/WorldStorage/WSSAnvil.cpp
+++ b/src/WorldStorage/WSSAnvil.cpp
@@ -431,7 +431,7 @@ bool cWSSAnvil::LoadChunkFromNBT(const cChunkCoords & a_Chunk, const cParsedNBT 
 		IsLightValid ? BlockLight : nullptr,
 		IsLightValid ? SkyLight : nullptr,
 		nullptr, Biomes,
-		Entities, BlockEntities,
+		std::move(Entities), std::move(BlockEntities),
 		false
 	));
 	m_World->QueueSetChunkData(SetChunkData);


### PR DESCRIPTION
cSetChunkData constructor changed to only accept rvalues. lvalues have to be explicitly converted with std::move() to clarify that the passed data will be invalidated.
(Technically left in a valid but unspecified state.)