### PR TITLE
PathFinder - Fixed nullptr chunk bug

### DIFF
--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -117,7 +117,7 @@ bool cPath::IsSolid(const Vector3d & a_Location)
 {
 	ASSERT(m_Chunk != nullptr);
 	m_Chunk = m_Chunk->GetNeighborChunk(a_Location.x, a_Location.z);
-	if (!m_Chunk->IsValid())
+	if ((m_Chunk == nullptr) || (!m_Chunk->IsValid()))
 	{
 		return true;
 	}


### PR DESCRIPTION
I fixed this:
```
        At Path.cpp. line 118:
    ASSERT(m_Chunk != nullptr);
    m_Chunk = m_Chunk->GetNeighborChunk(a_Location.x, a_Location.z);
        //Now m_Chunk is nullptr
    if (!m_Chunk->IsValid())   // CRASH
```
I still don't understand when does `m_Chunk->GetNeighborChunk` return a `nullptr `and I'd appreciate an explanation.
I didn't really test if it returned a `nullptr`, but it's unlikely that something's wrong with Chunk passed to the PathFinder by `tick(...)`, and this is the only other explanation I can think of.