### PR TITLE
PathFinder - Couple of bugfixes

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -143,10 +143,11 @@ bool cMonster::TickPathFinding(cChunk & a_Chunk)
 	{
 		/* If we reached the last path waypoint,
 		Or if we haven't re-calculated for too long.
-		Interval is proportional to distance squared. (Recalculate lots when close, calculate rarely when far) */
+		Interval is proportional to distance squared, and its minimum is 10.
+		(Recalculate lots when close, calculate rarely when far) */
 		if (
 			((GetPosition() - m_PathFinderDestination).Length() < 0.25) ||
-			m_TicksSinceLastPathReset > (0.15 * (m_FinalDestination - GetPosition()).SqrLength())
+			((m_TicksSinceLastPathReset > 10) && (m_TicksSinceLastPathReset > (0.15 * (m_FinalDestination - GetPosition()).SqrLength())))
 		)
 		{
 			ResetPathFinding();

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -60,12 +60,12 @@ cPath::cPath(
 	{
 		BLOCKTYPE BlockType;
 		NIBBLETYPE BlockMeta;
-		int RelX = m_Destination.x - m_Chunk->GetPosX() * cChunkDef::Width;
-		int RelZ = m_Destination.z - m_Chunk->GetPosZ() * cChunkDef::Width;
+		int RelX = m_Destination.x - Chunk->GetPosX() * cChunkDef::Width;
+		int RelZ = m_Destination.z - Chunk->GetPosZ() * cChunkDef::Width;
 		bool inwater = false;
 		for (;;)
 		{
-			m_Chunk->GetBlockTypeMeta(RelX, m_Destination.y, RelZ, BlockType, BlockMeta);
+			Chunk->GetBlockTypeMeta(RelX, m_Destination.y, RelZ, BlockType, BlockMeta);
 			if (BlockType != E_BLOCK_STATIONARY_WATER)
 			{
 				break;

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -182,7 +182,13 @@ bool cPath::Step_Internal()
 	}
 
 	// Path found.
-	if (CurrentCell->m_Location == m_Destination)
+	if (
+			(CurrentCell->m_Location == m_Destination + Vector3i(0, 0, 1)) ||
+			(CurrentCell->m_Location == m_Destination + Vector3i(1, 0, 0)) ||
+			(CurrentCell->m_Location == m_Destination + Vector3i(-1, 0, 0)) ||
+			(CurrentCell->m_Location == m_Destination + Vector3i(0, 0, -1)) ||
+			(CurrentCell->m_Location == m_Destination + Vector3i(0, -1, 0))
+	)
 	{
 		do
 		{


### PR DESCRIPTION
Couple of fixes, each in its own commit.

-Min recalculate interval is now half second (There was no minimum limit, it was CPU-wasteful)
-Fixed mobs not reaching a player when the player's bounding box is in the air (e.g. leaning with SHIFT)
-Fixed cChunk issues with swimming.