### PR TITLE
AI - Better shade cover

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -383,9 +383,9 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 		2. I was not hurt by a player recently.
 		Then STOP. */
 		if (
-			m_BurnsInDaylight && ((m_TicksSinceLastDamaged == 100) || (m_EMState == IDLE)) &&
-			WouldBurnAt(m_NextWayPointPosition, *Chunk->GetNeighborChunk(FloorC(m_NextWayPointPosition.x), FloorC(m_NextWayPointPosition.z))) &&
-			!WouldBurnAt(GetPosition(), *Chunk->GetNeighborChunk(FloorC(GetPosition().x), FloorC(GetPosition().z)))
+			m_BurnsInDaylight && ((m_TicksSinceLastDamaged >= 100) || (m_EMState == IDLE)) &&
+			WouldBurnAt(m_NextWayPointPosition, *Chunk) &&
+			!WouldBurnAt(GetPosition(), *Chunk)
 		)
 		{
 			// If we burn in daylight, and we would burn at the next step, and we won't burn where we are right now, and we weren't provoked recently:
@@ -1170,6 +1170,11 @@ void cMonster::HandleDaylightBurning(cChunk & a_Chunk, bool WouldBurn)
 
 bool cMonster::WouldBurnAt(Vector3d a_Location, cChunk & a_Chunk)
 {
+	cChunk * Chunk = a_Chunk.GetNeighborChunk(FloorC(m_NextWayPointPosition.x), FloorC(m_NextWayPointPosition.z));
+	if ((Chunk == nullptr) || (!Chunk->IsValid()))
+	{
+		return false;
+	}
 	int RelX = FloorC(a_Location.x) - a_Chunk.GetPosX() * cChunkDef::Width;
 	int RelY = FloorC(a_Location.y);
 	int RelZ = FloorC(a_Location.z) - a_Chunk.GetPosZ() * cChunkDef::Width;

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -378,7 +378,15 @@ void cMonster::Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk)
 	HandleDaylightBurning(*Chunk, WouldBurnAt(GetPosition(), *Chunk));
 	if (TickPathFinding(*Chunk))
 	{
-		if (m_BurnsInDaylight && WouldBurnAt(m_NextWayPointPosition, *Chunk->GetNeighborChunk(FloorC(m_NextWayPointPosition.x), FloorC(m_NextWayPointPosition.z))) && !IsOnFire() && (m_TicksSinceLastDamaged == 100))
+		/* If I burn in daylight, and I won't burn where I'm standing, and I'll burn in my next position, and at least one of those is true:
+		1. I am idle
+		2. I was not hurt by a player recently.
+		Then STOP. */
+		if (
+			m_BurnsInDaylight && ((m_TicksSinceLastDamaged == 100) || (m_EMState == IDLE)) &&
+			WouldBurnAt(m_NextWayPointPosition, *Chunk->GetNeighborChunk(FloorC(m_NextWayPointPosition.x), FloorC(m_NextWayPointPosition.z))) &&
+			!WouldBurnAt(GetPosition(), *Chunk->GetNeighborChunk(FloorC(GetPosition().x), FloorC(GetPosition().z)))
+		)
 		{
 			// If we burn in daylight, and we would burn at the next step, and we won't burn where we are right now, and we weren't provoked recently:
 			StopMovingToPosition();

--- a/src/Mobs/Monster.h
+++ b/src/Mobs/Monster.h
@@ -203,7 +203,17 @@ protected:
 	Returns if a path is ready, and therefore if the mob should move to m_NextWayPointPosition
 	*/
 	bool TickPathFinding(cChunk & a_Chunk);
+
+	/** Move in a straight line to the next waypoint in the path, will jump if needed. */
 	void MoveToWayPoint(cChunk & a_Chunk);
+
+	/** Ensures the destination is not buried underground or under water. Also ensures the destination is not in the air.
+	Only the Y coordinate of m_FinalDestination might be changed.
+	1. If m_FinalDestination is the position of a water block, m_FinalDestination's Y will be modified to point to the heighest water block in the pool in the current column.
+	2. If m_FinalDestination is the position of a solid, m_FinalDestination's Y will be modified to point to the first airblock above the solid in the current column.
+	3. If m_FinalDestination is the position of an air block, Y will keep decreasing until hitting either a solid or water.
+	Now either 1 or 2 is performed. */
+	bool EnsureProperDestination(cChunk & a_Chunk);
 
 	/** Resets a pathfinding task, be it due to failure or something else
 	Resets the pathfinder. If m_IsFollowingPath is true, TickPathFinding starts a brand new path.

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -54,31 +54,6 @@ cPath::cPath(
 		return;
 	}
 
-	// If destination in water, set water surface as destination.
-	cChunk * Chunk = m_Chunk->GetNeighborChunk(m_Destination.x, m_Destination.z);
-	if ((Chunk != nullptr) && Chunk->IsValid())
-	{
-		BLOCKTYPE BlockType;
-		NIBBLETYPE BlockMeta;
-		int RelX = m_Destination.x - Chunk->GetPosX() * cChunkDef::Width;
-		int RelZ = m_Destination.z - Chunk->GetPosZ() * cChunkDef::Width;
-		bool inwater = false;
-		for (;;)
-		{
-			Chunk->GetBlockTypeMeta(RelX, m_Destination.y, RelZ, BlockType, BlockMeta);
-			if (BlockType != E_BLOCK_STATIONARY_WATER)
-			{
-				break;
-			}
-			inwater = true;
-			m_Destination+=Vector3d(0, 1, 0);
-		}
-		if (inwater)
-		{
-			m_Destination+=Vector3d(0, -1, 0);
-		}
-	}
-
 	m_Status = ePathFinderStatus::CALCULATING;
 	m_StepsLeft = a_MaxSteps;
 


### PR DESCRIPTION
Changed the conditions of when the AI should remain in shade (doesn't fix the mushroom issue). Specifically, made the zombies light-sane even when idle and not chasing player.

The change is pretty trivial, it is very unlikely to break anything.