### PR TITLE
Fixed compiler warning overrides in Vector3.h

### DIFF
--- a/src/Vector3.h
+++ b/src/Vector3.h
@@ -80,14 +80,14 @@ public:
 
 	inline bool HasNonZeroLength(void) const
 	{
-		#ifndef __GNUC__
+		#ifdef __clang__
 		#pragma clang diagnostics push
 		#pragma clang diagnostics ignored "-Wfloat-equal"
 		#endif
 
 		return ((x != 0) || (y != 0) || (z != 0));
 
-		#ifndef __GNUC__
+		#ifdef __clang__
 		#pragma clang diagnostics pop
 		#endif
 	}
@@ -136,14 +136,14 @@ public:
 		// Perform a strict comparison of the contents - we want to know whether this object is exactly equal
 		// To perform EPS-based comparison, use the EqualsEps() function
 
-		#ifndef __GNUC__
+		#ifdef __clang__
 		#pragma clang diagnostics push
 		#pragma clang diagnostics ignored "-Wfloat-equal"
 		#endif
 
 		return !((x != a_Rhs.x) || (y != a_Rhs.y) || (z != a_Rhs.z));
 
-		#ifndef __GNUC__
+		#ifdef __clang__
 		#pragma clang diagnostics pop
 		#endif
 	}


### PR DESCRIPTION
Fixed my dumb. Now correctly uses a whitelist instead of a blacklist only for gcc.