### PR TITLE
Fixed possible crash in cProbabDistrib

### DIFF
--- a/src/ProbabDistrib.cpp
+++ b/src/ProbabDistrib.cpp
@@ -133,6 +133,7 @@ int cProbabDistrib::MapValue(int a_OrigValue) const
 	
 	// Linearly interpolate between Lo and Hi:
 	int ProbDif  = m_Cumulative[Hi].m_Probability - m_Cumulative[Lo].m_Probability;
+	ProbDif = (ProbDif != 0) ? ProbDif : 1;
 	int ValueDif = m_Cumulative[Hi].m_Value - m_Cumulative[Lo].m_Value;
 	return m_Cumulative[Lo].m_Value + (a_OrigValue - m_Cumulative[Lo].m_Probability) * ValueDif / ProbDif;
 }


### PR DESCRIPTION
It could divide through 0 which causes a crash.

I especialy noticed this in the nether