### PR TITLE
PathFinder - smart pointers

### DIFF
--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -215,11 +215,6 @@ bool cPath::Step_Internal()
 
 void cPath::FinishCalculation()
 {
-	for (auto && pair : m_Map)
-	{
-		delete pair.second;
-	}
-
 	m_Map.clear();
 	m_OpenList = std::priority_queue<cPathCell *, std::vector<cPathCell *>, compareHeuristics>{};
 }
@@ -348,7 +343,7 @@ cPathCell * cPath::GetCell(const Vector3i & a_Location)
 	{
 		Cell = new cPathCell();
 		Cell->m_Location = a_Location;
-		m_Map[a_Location] = Cell;
+		m_Map[a_Location] = UniquePtr<cPathCell>(Cell);
 		Cell->m_IsSolid = IsSolid(a_Location);
 		Cell->m_Status = eCellStatus::NOLIST;
 		#ifdef COMPILING_PATHFIND_DEBUGGER
@@ -360,6 +355,6 @@ cPathCell * cPath::GetCell(const Vector3i & a_Location)
 	}
 	else
 	{
-		return m_Map[a_Location];
+		return m_Map[a_Location].get();
 	}
 }

--- a/src/Mobs/Path.h
+++ b/src/Mobs/Path.h
@@ -131,7 +131,7 @@ private:
 
 	/* Pathfinding fields */
 	std::priority_queue<cPathCell *,  std::vector<cPathCell *>,  compareHeuristics> m_OpenList;
-	std::unordered_map<Vector3i,  cPathCell *, VectorHasher> m_Map;
+	std::unordered_map<Vector3i,  UniquePtr<cPathCell>, VectorHasher> m_Map;
 	Vector3i m_Destination;
 	Vector3i m_Source;
 	int m_StepsLeft;


### PR DESCRIPTION
This is not complete yet.
I am new to smart pointers so I won't be surprised if there are bad practices.
If you're wondering why there are still raw pointers around (and why I use get()), that's because I followed the guidelines in this [stack exchange answer] (http://stackoverflow.com/questions/8338570/c11-replace-all-non-owning-raw-pointers-with-stdshared-ptr). "Delete" should never be called on those raw pointers.
I would have preferred using a reference instead, but some functions need to return a nullptr, so I didn't.

Like I said, new to this. All advices welcome.