### PR TITLE
Issue #1868 and Issue #1984

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,6 +2,7 @@ Many people have contributed to MCServer, and this list attempts to broadcast at
 
 BasedDoge (Donated AlchemistVillage prefabs)
 bearbin (Alexander Harkness)
+beeduck
 derouinw
 Diusrex
 Duralex

--- a/src/Blocks/BlockDoor.cpp
+++ b/src/Blocks/BlockDoor.cpp
@@ -50,10 +50,24 @@ void cBlockDoorHandler::OnUse(cChunkInterface & a_ChunkInterface, cWorldInterfac
 	UNUSED(a_CursorY);
 	UNUSED(a_CursorZ);
 
-	if (a_ChunkInterface.GetBlock(a_BlockX, a_BlockY, a_BlockZ) == E_BLOCK_WOODEN_DOOR)
+	switch (a_ChunkInterface.GetBlock(a_BlockX, a_BlockY, a_BlockZ))
 	{
-		ChangeDoor(a_ChunkInterface, a_BlockX, a_BlockY, a_BlockZ);
-		a_Player->GetWorld()->BroadcastSoundParticleEffect(1003, a_BlockX, a_BlockY, a_BlockZ, 0, a_Player->GetClientHandle());
+		default:
+		{
+			ASSERT(!"Unhandled door block type");
+		}
+		case E_BLOCK_ACACIA_DOOR:
+		case E_BLOCK_BIRCH_DOOR:
+		case E_BLOCK_DARK_OAK_DOOR:
+		case E_BLOCK_JUNGLE_DOOR:
+		case E_BLOCK_SPRUCE_DOOR:
+		case E_BLOCK_IRON_DOOR:
+		case E_BLOCK_WOODEN_DOOR:
+		{
+			ChangeDoor(a_ChunkInterface, a_BlockX, a_BlockY, a_BlockZ);
+			a_Player->GetWorld()->BroadcastSoundParticleEffect(1003, a_BlockX, a_BlockY, a_BlockZ, 0, a_Player->GetClientHandle());
+			break;
+		}
 	}
 }
 

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -362,6 +362,7 @@ cWorld::~cWorld()
 void cWorld::CastThunderbolt (int a_BlockX, int a_BlockY, int a_BlockZ)
 {
 	BroadcastThunderbolt(a_BlockX, a_BlockY, a_BlockZ);
+	BroadcastSoundEffect("ambient.weather.thunder", a_BlockX, a_BlockY, a_BlockZ, 50, 1);
 }
 
 


### PR DESCRIPTION
Addressing issue #1868, I've added the sound effect for thunder. It is created with a fixed volume to be realistically heard over the sound of the rain.

I noticed that lightning is currently created at a fixed location (0, 0, 0), I was wondering if anyone is currently working on the TODO of changing lightning to be cast randomly near player locations. If not, I'd like to try and fix that as well. This would also probably change the fixed volume of the thunder sound effect.

I've also addressed issue #1984. Door open/close and sound effect handling was only looking for basic wooden door types.