### PR TITLE
Lua: Break into ZBS debugger on API errors.

### DIFF
--- a/src/Bindings/LuaState.h
+++ b/src/Bindings/LuaState.h
@@ -389,6 +389,9 @@ protected:
 	
 	/** Used as the error reporting function for function calls */
 	static int ReportFnCallErrors(lua_State * a_LuaState);
+
+	/** Tries to break into the MobDebug debugger, if it is installed. */
+	static int BreakIntoDebugger(lua_State * a_LuaState);
 } ;
 
 


### PR DESCRIPTION
When MCServer runs into a problem while executing the current Lua code, it will attempt to break into ZeroBrane Studio debugger before unloading the plugin.

If ZeroBrane Studio was not used to debug the server, nothing is executed.

This is dependent on pkulchenko/ZeroBranePackage#15