### PR TITLE
Fix sapling probability.

### DIFF
--- a/src/Blocks/BlockLeaves.h
+++ b/src/Blocks/BlockLeaves.h
@@ -41,7 +41,7 @@ public:
 		cFastRandom rand;
 
 		// Old leaves - 3 bits contain display; new leaves - 1st bit, shifted left two for saplings to understand
-		if (rand.NextInt(6) == 0)
+		if (rand.NextInt(20) == 0)
 		{
 			a_Pickups.push_back(
 				cItem(


### PR DESCRIPTION
Probability is 5% of leaves drop a sapling.

This should really be different for jungle leaves (2.5%) and the Fortune enchantment should increase the probability.