### PR TITLE
Fixed compile error in Monster.cpp

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -519,7 +519,7 @@ void cMonster::SetPitchAndYawFromDestination()
 		double HeadRotation, HeadPitch;
 		Distance.Normalize();
 		VectorToEuler(Distance.x, Distance.y, Distance.z, HeadRotation, HeadPitch);
-		if (fabs(BodyRotation - HeadRotation) < 120)
+        if (std::abs(BodyRotation - HeadRotation) < 120)
 		{
 			SetHeadYaw(HeadRotation);
 			SetPitch(-HeadPitch);

--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -519,7 +519,7 @@ void cMonster::SetPitchAndYawFromDestination()
 		double HeadRotation, HeadPitch;
 		Distance.Normalize();
 		VectorToEuler(Distance.x, Distance.y, Distance.z, HeadRotation, HeadPitch);
-		if (abs(BodyRotation - HeadRotation) < 120)
+		if (fabs(BodyRotation - HeadRotation) < 120)
 		{
 			SetHeadYaw(HeadRotation);
 			SetPitch(-HeadPitch);


### PR DESCRIPTION
On line 522 of Monster.cpp, abs() was being used instead of fabs() for variables of type double. I guess this compiled fine on other platforms, but on OS X it caused the build to fail.