### PR TITLE
Path recalculation improvements

### DIFF
--- a/src/Mobs/Monster.cpp
+++ b/src/Mobs/Monster.cpp
@@ -177,13 +177,14 @@ bool cMonster::TickPathFinding(cChunk & a_Chunk)
 		case ePathFinderStatus::NEARBY_FOUND:
 		{
 			m_NoPathToTarget = true;
-			m_Path->AcceptNearbyPath();
+			m_PathFinderDestination = m_Path->AcceptNearbyPath();
 			break;
 		}
 
 		case ePathFinderStatus::PATH_NOT_FOUND:
 		{
-			StopMovingToPosition();  // Give up pathfinding to that destination.
+			ResetPathFinding();  // Try to calculate a path again.
+			// Note that the next time may succeed, e.g. if a player breaks a barrier.
 			break;
 		}
 		case ePathFinderStatus::CALCULATING:

--- a/src/Mobs/Path.cpp
+++ b/src/Mobs/Path.cpp
@@ -6,6 +6,7 @@
 #include "Path.h"
 #include "../Chunk.h"
 
+
 #define DISTANCE_MANHATTAN 0  // 1: More speed, a bit less accuracy 0: Max accuracy, less speed.
 #define HEURISTICS_ONLY 0  // 1: Much more speed, much less accurate.
 #define CALCULATIONS_PER_STEP 10  // Higher means more CPU load but faster path calculations.
@@ -178,11 +179,18 @@ bool cPath::Step_Internal()
 
 	// Calculation not finished yet.
 	// Check if we have a new NearestPoint.
-	if (CurrentCell->m_H < m_NearestPointToTarget->m_H)
+
+	if ((m_Destination - CurrentCell->m_Location).Length() < 5)
+	{
+		if (m_Rand.NextInt(4) == 0)
+		{
+			m_NearestPointToTarget = CurrentCell;
+		}
+	}
+	else if (CurrentCell->m_H < m_NearestPointToTarget->m_H)
 	{
 		m_NearestPointToTarget = CurrentCell;
 	}
-
 	// process a currentCell by inspecting all neighbors.
 
 	// Check North, South, East, West on all 3 different heights.

--- a/src/Mobs/Path.h
+++ b/src/Mobs/Path.h
@@ -1,16 +1,13 @@
 
 #pragma once
 
-/* Wanna use the pathfinder? Put this in your header file:
-
-// Fwd: cPath
+/*
+// Needed Fwds: cPath
 enum class ePathFinderStatus;
 class cPath;
-
-Put this in your .cpp:
-#include "...Path.h"
 */
 
+#include "../FastRandom.h"
 #ifdef COMPILING_PATHFIND_DEBUGGER
 	/* Note: the COMPILING_PATHFIND_DEBUGGER flag is used by Native / WiseOldMan95 to debug
 	this class outside of MCServer. This preprocessor flag is never set when compiling MCServer. */
@@ -166,6 +163,7 @@ private:
 	Vector3i m_Source;
 	int m_StepsLeft;
 	cPathCell * m_NearestPointToTarget;
+	cFastRandom m_Rand;
 
 	/* Control fields */
 	ePathFinderStatus m_Status;


### PR DESCRIPTION
Mobs are now much less dull when there is no path to the player.

I also added an element of randomness, if you're unreachable, the mobs will not just stack up on the closest block to you. This partially fixes the mob stacking issue, when that is fixed we can remove the randomness, but I think it's actually awesome and can be kept anyways.