### PR TITLE
Fixed players head visible when in spectator mode

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -1205,6 +1205,15 @@ void cPlayer::SetGameMode(eGameMode a_GameMode)
 		SetCanFly(false);
 	}
 
+	if (IsGameModeSpectator() && IsVisible())
+	{
+		SetVisible(false);
+	}
+	else if (!IsVisible())
+	{
+		SetVisible(true);
+	}
+
 	m_World->BroadcastPlayerListUpdateGameMode(*this);
 }
 


### PR DESCRIPTION
Fix for #1980. It should be noted that my server will occasionally crash when BroadcastSpawnEntity() and BroadcastDestroyEntity() are called, which SetVisible() calls. I know these functions are used when monsters are killed as well.