### PR TITLE
Fix for players falling through world when loading in as spectator

### DIFF
--- a/src/Entities/Player.cpp
+++ b/src/Entities/Player.cpp
@@ -128,6 +128,13 @@ cPlayer::cPlayer(cClientHandlePtr a_Client, const AString & a_PlayerName) :
 			m_IsFlying = true;
 		}
 	}
+
+	if (m_GameMode == gmSpectator)  // If player is reconnecting to the server in spectator mode
+	{
+		m_CanFly = true;
+		m_IsFlying = true;
+		m_bVisible = false;
+	}
 	
 	cRoot::Get()->GetServer()->PlayerCreated(this);
 }


### PR DESCRIPTION
Fix for issue #2053. There were no checks for a player connecting to a server when they are already in spectator mode.