### PR TITLE
Fix #2105 - Add gcc to Travis CI compilers list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,27 @@
 language: cpp
-compiler: clang
+
+compiler: 
+- clang
+- gcc
 
 before_install:
-#  - if [ "$TRAVIS_MCSERVER_BUILD_TYPE" == "COVERAGE" ]; then sudo pip install cpp_coveralls; fi
-
-  # g++4.8
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq
 
 install:
-  # g++4.8 and clang
   - sudo apt-get install -qq g++-4.8
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
 
   # lua, needed for style checking and possibly later on for bindings generation
   - sudo apt-get install -qq lua5.1
-  
-  # g++4.8
-  - if [ "$CXX" == "g++" ]; then export CXX="g++-4.8"; export CC="gcc-4.8"; fi
 
-# Build MCServer
 script: ./CIbuild.sh
-
-#after_success:
-#  - ./uploadCoverage.sh
 
 env:
   - TRAVIS_MCSERVER_BUILD_TYPE=RELEASE MCSERVER_PATH=./MCServer
   - TRAVIS_MCSERVER_BUILD_TYPE=DEBUG   MCSERVER_PATH=./MCServer_debug
 
-#matrix:
-#  include:
-#    - compiler: gcc
-#      env: TRAVIS_MCSERVER_BUILD_TYPE=COVERAGE   MCSERVER_PATH=./MCServer
-
-# Notification Settings
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
As suggested in #2105, I propose my addition of `gcc` to `compilers` list in `.travis.yml`.

Tested in my own branch, Travis successfully builds with 4 configurations.
- clang RELEASE
- clang DEBUG
- gcc-4.8 RELEASE
- gcc-4.8 DEBUG

Additional info can be seen in the build https://travis-ci.org/cengizIO/MCServer/builds/63767724

I also decided to clean up commented lines in `.travis.yml`.

Regards.