### PR TITLE
Support building on FreeBSD

### DIFF
--- a/SetFlags.cmake
+++ b/SetFlags.cmake
@@ -240,6 +240,11 @@ macro(set_exe_flags)
 		# we support non-IEEE 754 fpus so can make no guarentees about error
 		add_flags_cxx("-ffast-math")
 
+		if(${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+			# backtrace() and friends are in libexecinfo
+			add_flags_lnk("-lexecinfo")
+		endif()
+
 		if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 			get_clang_version()
 			if ("${CLANG_VERSION}" VERSION_LESS 3.0)

--- a/lib/sqlite/CMakeLists.txt
+++ b/lib/sqlite/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 # FreeBSD requires us to define this to get POSIX 2001 standard
 if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-	add_flags_cxx(-D__POSIX_VISIBLE=200112)
+	add_flags_cxx("-D_XOPEN_SOURCE=600")
 endif()
 
 add_library(sqlite ${SOURCE})

--- a/lib/tolua++/CMakeLists.txt
+++ b/lib/tolua++/CMakeLists.txt
@@ -53,4 +53,8 @@ if(UNIX)
 target_link_libraries(tolua m ${DYNAMIC_LOADER})
 endif()
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+	add_flags_lnk(-L/usr/local/lib)
+endif()
+
 target_link_libraries(tolua tolualib lua)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -332,4 +332,9 @@ endif ()
 if (WIN32)
 	target_link_libraries(${EXECUTABLE} expat tolualib ws2_32.lib Psapi.lib)
 endif()
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+	add_flags_lnk(-L/usr/local/lib)
+endif()
+
 target_link_libraries(${EXECUTABLE} luaexpat jsoncpp mbedtls zlib sqlite lua SQLiteCpp event_core event_extra)

--- a/src/OSSupport/Errors.cpp
+++ b/src/OSSupport/Errors.cpp
@@ -22,7 +22,7 @@ AString GetOSErrorString( int a_ErrNo)
 	
 	// According to http://linux.die.net/man/3/strerror_r there are two versions of strerror_r():
 	
-	#if !defined(__APPLE__) && ( _GNU_SOURCE) && !defined(ANDROID_NDK)  // GNU version of strerror_r()
+	#if !defined(__APPLE__) && defined( _GNU_SOURCE) && !defined(ANDROID_NDK)  // GNU version of strerror_r()
 	
 	char * res = strerror_r( errno, buffer, ARRAYCOUNT(buffer));
 	if (res != nullptr)


### PR DESCRIPTION
SetFlags.cmake

	Add -lexecinfo to linker flags for FreeBSD to resolve backtrace()

lib/sqlite/CMakeLists.txt

	Define _XOPEN_SOURCE to 600 instead of __POSIX_VISIBLE to 200112 for
	POSIX 1-2001 support. For POSIX standards, the _XOPEN_SOURCE define
	controls the eventual value of __POSIX_VISIBLE. _XOPEN_SOURCE is defined
	to 500 in sqlite.c if not already defined, which sets up _POSIX_C_SOURCE
	and __POSIX_VISIBLE to the 199506 for POSIX.1c

lib/tolua++/CMakeLists.txt
src/CMakeLists.txt

	Add /usr/local/lib to the library search path for FreeBSD builds

src/OSSupport/Errors.cpp

	Correct the strerror_r() implementation determination to check whether
	_GNU_SOURCE is defined, not what it evaluates to