### PR TITLE
Fix for chat and player lists with players in separate worlds

### DIFF
--- a/src/ClientHandle.cpp
+++ b/src/ClientHandle.cpp
@@ -381,8 +381,8 @@ void cClientHandle::Authenticate(const AString & a_Name, const AString & a_UUID,
 
 	// Send player list items
 	SendPlayerListAddPlayer(*m_Player);
-	World->BroadcastPlayerListAddPlayer(*m_Player);
-	World->SendPlayerList(m_Player);
+	cRoot::Get()->BroadcastPlayerListsAddPlayer(*m_Player);
+	cRoot::Get()->SendPlayerLists(m_Player);
 
 	m_Player->Initialize(*World);
 	m_State = csAuthenticated;
@@ -1475,7 +1475,7 @@ void cClientHandle::HandleChat(const AString & a_Message)
 	Msg.AddTextPart(AString("<") + m_Player->GetName() + "> ", Color);
 	Msg.ParseText(Message);
 	Msg.UnderlineUrls();
-	m_Player->GetWorld()->BroadcastChat(Msg);
+	cRoot::Get()->BroadcastChat(Msg);
 }
 
 

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -558,6 +558,23 @@ void cRoot::SaveAllChunks(void)
 
 
 
+void cRoot::SendPlayerLists(cPlayer * a_DestPlayer)
+{
+	for (const auto & itr : m_WorldsByName)
+	{
+		itr.second->SendPlayerList(a_DestPlayer);
+	}  // for itr - m_WorldsByName[]
+}
+
+
+
+void cRoot::BroadcastPlayerListsAddPlayer(const cPlayer & a_Player, const cClientHandle * a_Exclude)
+{
+	for (const auto & itr : m_WorldsByName)
+	{
+		itr.second->BroadcastPlayerListAddPlayer(a_Player);
+	}  // for itr - m_WorldsByName[]
+}
 
 
 void cRoot::BroadcastChat(const AString & a_Message, eMessageType a_ChatPrefix)
@@ -579,8 +596,6 @@ void cRoot::BroadcastChat(const cCompositeChat & a_Message)
 		itr->second->BroadcastChat(a_Message);
 	}  // for itr - m_WorldsByName[]
 }
-
-
 
 
 

--- a/src/Root.h
+++ b/src/Root.h
@@ -145,6 +145,12 @@ public:
 	/** Finds the player using it's complete username and calls the callback */
 	bool DoWithPlayer(const AString & a_PlayerName, cPlayerListCallback & a_Callback);
 
+	/** Send playerlist of all worlds to player */
+	void SendPlayerLists(cPlayer * a_DestPlayer);
+
+	/** Broadcast Player through all worlds */
+	void BroadcastPlayerListsAddPlayer(const cPlayer & a_Player, const cClientHandle * a_Exclude = nullptr);
+
 	// tolua_begin
 
 	/// Sends a chat message to all connected clients (in all worlds)


### PR DESCRIPTION
Issue #2106
I've changed the way clients connecting to the server receive player lists. Before this change, the connecting client only requested the player list from the world they were initially connecting in. This behavior caused players in other worlds to not appear on the newly connected player's player list as well as appearing invisible when they finally see each other. I changed this by adding a function to cRoot that iterates through all current worlds sending their player list to the requesting client.

I've also made a change to broadcasting chat. Originally chat was only broadcast to the world of the sender, it is not broadcast server wide to all worlds.

There is another pull request for this issue that I closed. I had to force push and clean up my fork.