### PR TITLE
Fix FreeBSD/clang errors caused by -Werror

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ jasperarmstrong
 keyboard
 Lapayo
 Luksor
+linnemannr (Reid Linnemann)
 M10360
 marmot21
 Masy98

--- a/src/Generating/FinishGen.cpp
+++ b/src/Generating/FinishGen.cpp
@@ -1375,8 +1375,12 @@ eMonsterType cFinishGenPassiveMobs::GetRandomMob(cChunkDesc & a_ChunkDesc)
 		return mtInvalidType;
 	}
 
-	size_t RandMob = static_cast<size_t>((m_Noise.IntNoise2DInt(chunkX - chunkZ + 2, chunkX + 5) / 7)) % ListOfSpawnables.size();
 	auto MobIter = ListOfSpawnables.begin();
+	using diff_type =
+		std::iterator_traits<decltype(MobIter)>::difference_type;
+	diff_type RandMob = static_cast<diff_type>
+		((unsigned long)(m_Noise.IntNoise2DInt(chunkX - chunkZ + 2, chunkX + 5) / 7)
+		% ListOfSpawnables.size());
 	std::advance(MobIter, RandMob);
 
 	return *MobIter;

--- a/src/OSSupport/StackTrace.cpp
+++ b/src/OSSupport/StackTrace.cpp
@@ -12,6 +12,13 @@
 	#include <unistd.h>
 #endif
 
+// FreeBSD uses size_t for the return type of backtrace()
+#if defined(__FreeBSD__) && (__FreeBSD__ >= 10)
+	#define btsize size_t
+#else
+	#define btsize int
+#endif
+
 
 
 
@@ -34,7 +41,7 @@ void PrintStackTrace(void)
 		// Use the backtrace() function to get and output the stackTrace:
 		// Code adapted from http://stackoverflow.com/questions/77005/how-to-generate-a-stacktrace-when-my-gcc-c-app-crashes
 		void * stackTrace[30];
-		int numItems = backtrace(stackTrace, ARRAYCOUNT(stackTrace));
+		btsize numItems = backtrace(stackTrace, ARRAYCOUNT(stackTrace));
 		backtrace_symbols_fd(stackTrace, numItems, STDERR_FILENO);
 	#endif
 }

--- a/src/StringUtils.h
+++ b/src/StringUtils.h
@@ -168,6 +168,12 @@ bool StringToInteger(const AString & a_str, T & a_Num)
 	}
 	else
 	{
+		// Unsigned result cannot be signed!
+		if (!std::numeric_limits<T>::is_signed)
+		{
+			return false;
+		}
+
 		for (size_t size = a_str.size(); i < size; i++)
 		{
 			if ((a_str[i] < '0') || (a_str[i] > '9'))


### PR DESCRIPTION
With FreeBSD/clang, -Werror combined with the configured warning flags yields
some fatal errors, specifically related to signed conversion, 64 to 32 bit
conversion, and tautological compares.

CONTRIBUTORS

	Add myself to the contributor list

src/Generating/FinishGen.cpp

	In cFinishGenPassiveMobs::GetRandomMob(), change the type of RandMob
	from size_t to the difference_type of the ListOfSpawnables iterator
	MobIter. Using size_t triggers a 64 bit to 32 bit conversion if the
	difference_type of the iterator class is 64 bit

	Also explicitly cast the noise expression to unsigned long so we don't
	get a signed conversion warning from the modulo against
	ListOfSpawnables.size()

src/OSSupport/StackTrace.cpp

	FreeBSD 10 and above includes a non glibc implementation of benchmark()
	for which size_t, not int, is the return type. To account for this and
	prevent a signed conversion warning, abstract the type for numItems with
	a macro btsize

src/StringUtils.h

	In StringToInteger(), correct a tautological compare warning for
	unsigned types with the template. If T is unsigned, comparing
	std::numeric_limits<T>::min() to the unsigned result is always
	false. That control can enter this branch in an evaluated template with
	an unsigned type T may also permit a signed number to be parsed and
	erroneously stripped of its signedness at runtime. To guard against this
	and avoid the warning in the case that the number parsed from the string
	is non-positive, return false and don't try to parse if T is unsigned
	and control enters the non-positive branch