### PR TITLE
Use the new style command line parameters for Windows Service support.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,6 +3,7 @@ Many people have contributed to MCServer, and this list attempts to broadcast at
 BasedDoge (Donated AlchemistVillage prefabs)
 bearbin (Alexander Harkness)
 beeduck
+birkett (Anthony Birkett)
 derouinw
 Diusrex
 Duralex

--- a/MCServer/install_windows_service.cmd
+++ b/MCServer/install_windows_service.cmd
@@ -3,5 +3,5 @@ rem Alter this if you need to install multiple instances.
 set SERVICENAME="MCServer"
 
 set CURRENTDIR=%CD%
-sc create %SERVICENAME% binPath= "%CURRENTDIR%\MCServer.exe /service" start= auto DisplayName= %SERVICENAME%
+sc create %SERVICENAME% binPath= "%CURRENTDIR%\MCServer.exe -d" start= auto DisplayName= %SERVICENAME%
 sc description %SERVICENAME% "Minecraft server instance"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -382,6 +382,10 @@ std::unique_ptr<cMemorySettingsRepository> parseArguments(int argc, char **argv)
 
 		TCLAP::SwitchArg noBufArg("", "no-output-buffering", "Disable output buffering", cmd);
 
+		TCLAP::SwitchArg runAsServiceArg("d", "run-as-service", "Run as a service on Windows", cmd);
+
+		cmd.ignoreUnmatched(true);
+
 		cmd.parse(argc, argv);
 
 		auto repo = cpp14::make_unique<cMemorySettingsRepository>();
@@ -418,6 +422,11 @@ std::unique_ptr<cMemorySettingsRepository> parseArguments(int argc, char **argv)
 		if (noBufArg.getValue())
 		{
 			setvbuf(stdout, nullptr, _IONBF, 0);
+		}
+
+		if (runAsServiceArg.getValue())
+		{
+			cRoot::m_RunAsService = true;
 		}
 
 		repo->SetReadOnly();
@@ -493,16 +502,6 @@ int main(int argc, char **argv)
 	
 	auto argsRepo = parseArguments(argc, argv);
 	
-	// Check if comm logging is to be enabled:
-	for (int i = 0; i < argc; i++)
-	{
-		AString Arg(argv[i]);
-		if (NoCaseCompare(Arg, "/service") == 0)
-		{
-			cRoot::m_RunAsService = true;
-		}
-	}  // for i - argv[]
-
 	#if defined(_WIN32)
 	// Attempt to run as a service
 	if (cRoot::m_RunAsService)


### PR DESCRIPTION
Fixes service support on Windows by swapping to the "-d" (daemon) switch instead of "/service". Plays nicely with TCLAP.

Also, ignore unmatched parameters, preventing unhanded exceptions.

See issue #2181 