### PR TITLE
Fixed warnings in MSVC.

### DIFF
--- a/src/Blocks/BlockButton.h
+++ b/src/Blocks/BlockButton.h
@@ -73,7 +73,12 @@ public:
 				return 0x0;
 			}
 		}
+		#if !defined(__clang__)
+			ASSERT(!"Unknown BLOCK_FACE");
+			return 0;
+		#endif
 	}
+
 
 	inline static eBlockFace BlockMetaDataToBlockFace(NIBBLETYPE a_Meta)
 	{
@@ -92,6 +97,7 @@ public:
 			}
 		}
 	}
+
 
 	virtual bool CanBeAt(cChunkInterface & a_ChunkInterface, int a_RelX, int a_RelY, int a_RelZ, const cChunk & a_Chunk) override
 	{

--- a/src/Blocks/BlockCocoaPod.h
+++ b/src/Blocks/BlockCocoaPod.h
@@ -89,6 +89,10 @@ public:
 				return 0;
 			}
 		}
+		#if !defined(__clang__)
+			ASSERT(!"Unknown BLOCK_FACE");
+			return 0;
+		#endif
 	}
 
 } ;

--- a/src/Blocks/BlockLadder.h
+++ b/src/Blocks/BlockLadder.h
@@ -64,6 +64,10 @@ public:
 				return 0x2;
 			}
 		}
+		#if !defined(__clang__)
+			ASSERT(!"Unknown BLOCK_FACE");
+			return 0;
+		#endif
 	}
 
 

--- a/src/Blocks/BlockLever.h
+++ b/src/Blocks/BlockLever.h
@@ -67,6 +67,10 @@ public:
 			case BLOCK_FACE_YM:   return 0x0;
 			case BLOCK_FACE_NONE: return 0x6;
 		}
+		#if !defined(__clang__)
+			ASSERT(!"Unknown BLOCK_FACE");
+			return 0;
+		#endif
 	}
 
 

--- a/src/Blocks/BlockQuartz.h
+++ b/src/Blocks/BlockQuartz.h
@@ -36,6 +36,7 @@ public:
 		return true;
 	}
 
+
 	inline static NIBBLETYPE BlockFaceToMetaData(eBlockFace a_BlockFace, NIBBLETYPE a_QuartzMeta)
 	{
 		switch (a_BlockFace)
@@ -64,5 +65,9 @@ public:
 				return a_QuartzMeta;  // No idea, give a special meta (all sides the same)
 			}
 		}
+		#if !defined(__clang__)
+			ASSERT(!"Unknown BLOCK_FACE");
+			return 0;
+		#endif
 	}
 } ;

--- a/src/Blocks/BlockSideways.h
+++ b/src/Blocks/BlockSideways.h
@@ -64,6 +64,10 @@ public:
 				return a_Meta | 0xC;  // No idea, give a special meta
 			}
 		}
+		#if !defined(__clang__)
+			ASSERT(!"Unknown BLOCK_FACE");
+			return 0;
+		#endif
 	}
 } ;
 

--- a/src/Blocks/BlockTrapdoor.h
+++ b/src/Blocks/BlockTrapdoor.h
@@ -66,6 +66,7 @@ public:
 		return true;
 	}
 	
+
 	inline static NIBBLETYPE BlockFaceToMetaData(eBlockFace a_BlockFace)
 	{
 		switch (a_BlockFace)
@@ -82,7 +83,12 @@ public:
 				return 0;
 			}
 		}
+		#if !defined(__clang__)
+			ASSERT(!"Unknown BLOCK_FACE");
+			return 0;
+		#endif
 	}
+
 
 	inline static eBlockFace BlockMetaDataToBlockFace(NIBBLETYPE a_Meta)
 	{
@@ -99,6 +105,7 @@ public:
 			}
 		}
 	}
+
 
 	virtual bool CanBeAt(cChunkInterface & a_ChunkInterface, int a_RelX, int a_RelY, int a_RelZ, const cChunk & a_Chunk) override
 	{

--- a/src/Blocks/BlockTripwireHook.h
+++ b/src/Blocks/BlockTripwireHook.h
@@ -16,6 +16,7 @@ public:
 	{
 	}
 
+
 	virtual bool GetPlacementBlockTypeMeta(
 		cChunkInterface & a_ChunkInterface, cPlayer * a_Player,
 		int a_BlockX, int a_BlockY, int a_BlockZ, eBlockFace a_BlockFace,
@@ -28,6 +29,7 @@ public:
 
 		return true;
 	}
+
 
 	inline static NIBBLETYPE DirectionToMetadata(eBlockFace a_Direction)
 	{
@@ -45,7 +47,12 @@ public:
 				return 0x0;
 			}
 		}
+		#if !defined(__clang__)
+			ASSERT(!"Unknown BLOCK_FACE");
+			return 0;
+		#endif
 	}
+
 
 	inline static eBlockFace MetadataToDirection(NIBBLETYPE a_Meta)
 	{
@@ -58,6 +65,7 @@ public:
 			default: ASSERT(!"Unhandled tripwire hook metadata!"); return BLOCK_FACE_NONE;
 		}
 	}
+
 
 	virtual void ConvertToPickups(cItems & a_Pickups, NIBBLETYPE a_BlockMeta) override
 	{

--- a/src/Defines.h
+++ b/src/Defines.h
@@ -245,6 +245,10 @@ inline eBlockFace MirrorBlockFaceY(eBlockFace a_BlockFace)
 			return a_BlockFace;
 		};
 	}
+	#if !defined(__clang__)
+		ASSERT(!"Unknown BLOCK_FACE");
+		return a_BlockFace;
+	#endif
 }
 
 
@@ -267,6 +271,10 @@ inline eBlockFace RotateBlockFaceCCW(eBlockFace a_BlockFace)
 			return a_BlockFace;
 		}
 	}
+	#if !defined(__clang__)
+		ASSERT(!"Unknown BLOCK_FACE");
+		return a_BlockFace;
+	#endif
 }
 
 
@@ -288,7 +296,15 @@ inline eBlockFace RotateBlockFaceCW(eBlockFace a_BlockFace)
 			return a_BlockFace;
 		};
 	}
+	#if !defined(__clang__)
+		ASSERT(!"Unknown BLOCK_FACE");
+		return a_BlockFace;
+	#endif
 }
+
+
+
+
 
 inline eBlockFace ReverseBlockFace(eBlockFace  a_BlockFace)
 {
@@ -302,7 +318,14 @@ inline eBlockFace ReverseBlockFace(eBlockFace  a_BlockFace)
 		case BLOCK_FACE_ZM:   return BLOCK_FACE_ZP;
 		case BLOCK_FACE_NONE: return a_BlockFace;
 	}
+	#if !defined(__clang__)
+		ASSERT(!"Unknown BLOCK_FACE");
+		return a_BlockFace;
+	#endif
 }
+
+
+
 
 
 /** Returns the textual representation of the BlockFace constant. */
@@ -320,7 +343,7 @@ inline AString BlockFaceToString(eBlockFace a_BlockFace)
 	}
 	// clang optimisises this line away then warns that it has done so.
 	#if !defined(__clang__)
-	return Printf("Unknown BLOCK_FACE: %d", a_BlockFace);
+		return Printf("Unknown BLOCK_FACE: %d", a_BlockFace);
 	#endif
 }
 

--- a/src/Entities/HangingEntity.h
+++ b/src/Entities/HangingEntity.h
@@ -46,12 +46,16 @@ public:
 
 protected:
 
+	Byte m_Facing;
+
+
 	virtual void SpawnOn(cClientHandle & a_ClientHandle) override;
 	virtual void Tick(std::chrono::milliseconds a_Dt, cChunk & a_Chunk) override
 	{
 		UNUSED(a_Dt);
 		UNUSED(a_Chunk);
 	}
+
 
 	/** Converts protocol hanging item facing to eBlockFace values */
 	inline static eBlockFace ProtocolFaceToBlockFace(Byte a_ProtocolFace)
@@ -77,6 +81,7 @@ protected:
 		return Dir;
 	}
 
+
 	/** Converts eBlockFace values to protocol hanging item faces */
 	inline static Byte BlockFaceToProtocolFace(eBlockFace a_BlockFace)
 	{
@@ -99,13 +104,17 @@ protected:
 
 				Dir = cHangingEntity::BlockFaceToProtocolFace(BLOCK_FACE_XP);
 			}
+			#if !defined(__clang__)
+			default:
+			{
+				ASSERT(!"Unknown BLOCK_FACE");
+				return 0;
+			}
+			#endif
 		}
 
 		return Dir;
 	}
-
-	Byte m_Facing;
-
 };  // tolua_export
 
 

--- a/src/Generating/MineShafts.cpp
+++ b/src/Generating/MineShafts.cpp
@@ -787,6 +787,13 @@ void cMineShaftCorridor::PlaceChest(cChunkDesc & a_ChunkDesc)
 			Meta = E_META_CHEST_FACING_XP;
 			break;
 		}
+		#if !defined(__clang__)
+		default:
+		{
+			ASSERT(!"Unknown direction");
+			return;
+		}
+		#endif
 	}  // switch (Dir)
 
 	if (

--- a/src/MobCensus.cpp
+++ b/src/MobCensus.cpp
@@ -48,6 +48,10 @@ int cMobCensus::GetCapMultiplier(cMonster::eFamily a_MobFamily)
 			return -1;
 		}
 	}
+	#if !defined(__clang__)
+		ASSERT(!"Unknown mob family");
+		return -1;
+	#endif
 }
 
 

--- a/src/WorldStorage/FastNBT.cpp
+++ b/src/WorldStorage/FastNBT.cpp
@@ -257,6 +257,9 @@ bool cParsedNBT::ReadTag(void)
 			return true;
 		}
 		
+		#if !defined(__clang__)
+		default:
+		#endif
 		case TAG_Min:
 		{
 			ASSERT(!"Unhandled NBT tag type");


### PR DESCRIPTION
It complained about undefined return values or using uninitialized variables.