### PR TITLE
Added cmdline params for crashdump detailness.

### DIFF
--- a/Install/MCServer_high_detail_debug.cmd
+++ b/Install/MCServer_high_detail_debug.cmd
@@ -1,1 +1,1 @@
-MCServer /cdf
+MCServer --crash-dump-full

--- a/Install/MCServer_medium_detail_debug.cmd
+++ b/Install/MCServer_medium_detail_debug.cmd
@@ -1,1 +1,1 @@
-MCServer /cdg
+MCServer --crash-dump-globals


### PR DESCRIPTION
Win32-only, also fixed the call scripts.
Fixes #2184.

Sanity-reformatted the source file.