### PR TITLE
Fix for special characters showing incorrectly on signs

### DIFF
--- a/src/Globals.h
+++ b/src/Globals.h
@@ -251,6 +251,7 @@ template class SizeChecker<UInt8,  1>;
 #include <deque>
 #include <string>
 #include <map>
+#include <unordered_map>
 #include <algorithm>
 #include <memory>
 #include <set>

--- a/src/Protocol/Protocol18x.cpp
+++ b/src/Protocol/Protocol18x.cpp
@@ -2548,10 +2548,32 @@ void cProtocol180::HandlePacketUpdateSign(cByteBuffer & a_ByteBuffer)
 		return;
 	}
 
+	std::unordered_map<AString, AString> SpecialCharacters;
+	SpecialCharacters["\\u0026"] = "&";
+	SpecialCharacters["\\u0027"] = "'";
+	SpecialCharacters["\\\""] = "\"";
+	SpecialCharacters["\\u003c"] = "<";
+	SpecialCharacters["\\u003e"] = ">";
+	SpecialCharacters["\\u003d"] = "=";
+
 	AString Lines[4];
 	for (int i = 0; i < 4; i++)
 	{
 		HANDLE_READ(a_ByteBuffer, ReadVarUTF8String, AString, Line);
+
+		// Buffer receives special characters in JSON code for sign messages, use SpecialCharacters map to parse them
+		for (const auto & itr : SpecialCharacters)
+		{
+			size_t Index = 0;
+			while (Index < Line.length())
+			{
+				if ((Index = Line.find(itr.first)) != AString::npos)
+				{
+					Line.replace(Index, itr.first.length(), itr.second);
+				}
+			}
+		}
+
 		Lines[i] = Line.substr(1, Line.length() - 2);  // Remove ""
 	}
 


### PR DESCRIPTION
Fix for issue #2170
For some reason the buffer for signs is receiving some special characters in JSON code. I checked the Minecraft protocol - signs receive four chat fields, which are the same field that are used for chat messages. For signs specific characters & ' " < > = are still encoded for some reason, but the error is not occurring for chat messages.
I implemented a parser to handle the codes in the mean time.