### PR TITLE
Daemon support on Linux

### DIFF
--- a/Tools/MCADefrag/MCADefrag.cpp
+++ b/Tools/MCADefrag/MCADefrag.cpp
@@ -22,7 +22,7 @@ static const Byte g_Zeroes[4096] = {0};
 
 int main(int argc, char ** argv)
 {
-	cLogger::cListener * consoleLogListener = MakeConsoleListener();
+	cLogger::cListener * consoleLogListener = MakeConsoleListener(false);
 	cLogger::cListener * fileLogListener = new cFileListener();
 	cLogger::GetInstance().AttachListener(consoleLogListener);
 	cLogger::GetInstance().AttachListener(fileLogListener);

--- a/Tools/ProtoProxy/ProtoProxy.cpp
+++ b/Tools/ProtoProxy/ProtoProxy.cpp
@@ -16,7 +16,7 @@ int main(int argc, char ** argv)
 {
 	// Initialize logging subsystem:
 	cLogger::InitiateMultithreading();
-	auto consoleLogListener = MakeConsoleListener();
+	auto consoleLogListener = MakeConsoleListener(false);
 	auto fileLogListener = new cFileListener();
 	cLogger::GetInstance().AttachListener(consoleLogListener);
 	cLogger::GetInstance().AttachListener(fileLogListener);

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -221,6 +221,7 @@ template class SizeChecker<UInt8,  1>;
 	#include <semaphore.h>
 	#include <errno.h>
 	#include <fcntl.h>
+	#include <unistd.h>
 #endif
 
 #if defined(ANDROID_NDK)

--- a/src/LoggerListeners.cpp
+++ b/src/LoggerListeners.cpp
@@ -238,8 +238,26 @@ public:
 
 
 
-cLogger::cListener * MakeConsoleListener(void)
+// Listener for when stdout is closed, i.e. When running as a daemon.
+class cNullConsoleListener
+	: public cLogger::cListener
 {
+	virtual void Log(AString a_Message, cLogger::eLogLevel a_LogLevel) override
+	{
+	}
+};
+
+
+
+
+
+cLogger::cListener * MakeConsoleListener(bool a_IsService)
+{
+	if (a_IsService)
+	{
+		return new cNullConsoleListener;
+	}
+
 	#ifdef _WIN32
 		// See whether we are writing to a console the default console attrib:
 		bool ShouldColorOutput = (_isatty(_fileno(stdin)) != 0);

--- a/src/LoggerListeners.h
+++ b/src/LoggerListeners.h
@@ -25,7 +25,7 @@ private:
 
 
 
-cLogger::cListener * MakeConsoleListener();
+cLogger::cListener * MakeConsoleListener(bool a_IsService);
 
 
 

--- a/src/Root.cpp
+++ b/src/Root.cpp
@@ -106,7 +106,7 @@ void cRoot::Start(std::unique_ptr<cSettingsRepositoryInterface> overridesRepo)
 	EnableMenuItem(hmenu, SC_CLOSE, MF_GRAYED);  // Disable close button when starting up; it causes problems with our CTRL-CLOSE handling
 	#endif
 
-	cLogger::cListener * consoleLogListener = MakeConsoleListener();
+	cLogger::cListener * consoleLogListener = MakeConsoleListener(m_RunAsService);
 	cLogger::cListener * fileLogListener = new cFileListener();
 	cLogger::GetInstance().AttachListener(consoleLogListener);
 	cLogger::GetInstance().AttachListener(fileLogListener);


### PR DESCRIPTION
Enable MCServer to run as a daemon on *nix like systems. This will make the GSP's happy down the road.

This uses the same "-d" switch, as introduced originally with the Windows service support.

I don't consider this ready to merge yet. It needs testing on Mac and RaspberryPi. I would also like to create a set of example init scripts (Debian, sysvinit and systemd).